### PR TITLE
chore: release v2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ checksum = "b985e394ee53f8e4c547d5c6fa75b83b243ab6f51563a0323f1475fc8abc8e7f"
 
 [[package]]
 name = "shapely"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "shapely-core",
  "shapely-derive",
@@ -78,11 +78,11 @@ dependencies = [
 
 [[package]]
 name = "shapely-core"
-version = "1.0.0"
+version = "2.0.0"
 
 [[package]]
 name = "shapely-derive"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "shapely-core",
  "unsynn",
@@ -90,14 +90,14 @@ dependencies = [
 
 [[package]]
 name = "shapely-json"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "shapely",
 ]
 
 [[package]]
 name = "shapely-yaml"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "shapely-core",
  "yaml-rust2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shapely", "shapely-core", "shapely-derive", "shapely-json", "shapely
 resolver = "3"
 
 [workspace.package]
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Amos Wenger <amos@bearcove.eu>"]
 edition = "2024"
 rust-version = "1.85"
@@ -22,7 +22,7 @@ keywords = [
 categories = ["encoding", "parsing", "development-tools", "data-structures"]
 
 [workspace.dependencies]
-shapely = { version = "1.0.0", path = "shapely" }
-shapely-core = { version = "1.0.0", path = "shapely-core" }
-shapely-derive = { version = "1.0.0", path = "shapely-derive" }
+shapely = { version = "2.0.0", path = "shapely" }
+shapely-core = { version = "2.0.0", path = "shapely-core" }
+shapely-derive = { version = "2.0.0", path = "shapely-derive" }
 unsynn = "0.0.25"

--- a/shapely-core/CHANGELOG.md
+++ b/shapely-core/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.0.0](https://github.com/bearcove/shapely/compare/shapely-core-v1.0.0...shapely-core-v2.0.0) - 2025-03-11
+
+### Other
+
+- Stub out shapely-yaml
+- Simplify Shape name function signature
+- Clean up HashMap's name impl
+- Change Shape.name from static str to NameFn
+- Note on valid zst pointer values, closes #11
+- Back to something working
+- Clippy auto fix
+- Add `addr` and `shape` methods to Partial and Slot
+- Looking good!
+- Refactor slot_by_name and move_into
+- Refactor Partial struct initialization and field access
+- more slot/field cleanups
+- Clean up Partial API
+- clean up drop impls
+- more work on the field API
+- Shape up field API
+- Stability notes
+- introduce slot_by_index / slot_by_name
+- link to 'free of syn' campaign
+- wip sloterrors
+- Ensure no syn dependency (and badge about it), closes #9

--- a/shapely-derive/CHANGELOG.md
+++ b/shapely-derive/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.0.0](https://github.com/bearcove/shapely/compare/shapely-derive-v1.0.0...shapely-derive-v2.0.0) - 2025-03-11
+
+### Other
+
+- Stub out shapely-yaml
+- Simplify Shape name function signature
+- Change Shape.name from static str to NameFn
+- Stability notes
+- link to 'free of syn' campaign
+- Ensure no syn dependency (and badge about it), closes #9
+- Introduce core crate
+- Get rid of debug/display, closes #4

--- a/shapely-json/CHANGELOG.md
+++ b/shapely-json/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.0.0](https://github.com/bearcove/shapely/compare/shapely-json-v1.0.0...shapely-json-v2.0.0) - 2025-03-11
+
+### Other
+
+- Simplify Shape name function signature
+- Change Shape.name from static str to NameFn
+- Back to something working
+- Tests pass again
+- Add `addr` and `shape` methods to Partial and Slot
+- Looking good!
+- Clean up Partial API
+- Shape up field API
+- Stability notes
+- introduce slot_by_index / slot_by_name
+- link to 'free of syn' campaign
+- Ensure no syn dependency (and badge about it), closes #9
+- Introduce core crate
+- Get rid of debug/display, closes #4

--- a/shapely-yaml/CHANGELOG.md
+++ b/shapely-yaml/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.0.0](https://github.com/bearcove/shapely/compare/shapely-yaml-v1.0.0...shapely-yaml-v2.0.0) - 2025-03-11
+
+### Other
+
+- Stub out shapely-yaml

--- a/shapely/CHANGELOG.md
+++ b/shapely/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.0.0](https://github.com/bearcove/shapely/compare/shapely-v1.0.0...shapely-v2.0.0) - 2025-03-11
+
+### Other
+
+- Change Shape.name from static str to NameFn
+- Looking good!
+- clean up drop impls
+- Stability notes
+- link to 'free of syn' campaign
+- Make derive unconditional, closes #8
+- Get rid of insta, closes #10
+- Ensure no syn dependency (and badge about it), closes #9
+- Introduce core crate
+- Get rid of debug/display, closes #4
+- Start implementing transparent


### PR DESCRIPTION



## 🤖 New release

* `shapely-core`: 1.0.0 -> 2.0.0 (⚠ API breaking changes)
* `shapely-derive`: 1.0.0 -> 2.0.0
* `shapely`: 1.0.0 -> 2.0.0 (⚠ API breaking changes)
* `shapely-json`: 1.0.0 -> 2.0.0 (✓ API compatible changes)
* `shapely-yaml`: 1.0.0 -> 2.0.0

### ⚠ `shapely-core` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/enum_missing.ron

Failed in:
  enum shapely_core::InitFieldSlot, previously in file /tmp/.tmpnGMAun/shapely-core/src/partial.rs:345

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant Origin::Borrowed 0 -> 1 in /tmp/.tmp0ovIur/shapely/shapely-core/src/partial.rs:12
  variant Origin::HeapAllocated 1 -> 0 in /tmp/.tmp0ovIur/shapely/shapely-core/src/partial.rs:8

--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field init_mark of variant Origin::Borrowed in /tmp/.tmp0ovIur/shapely/shapely-core/src/partial.rs:14

--- failure enum_struct_variant_field_missing: pub enum struct variant's field removed or renamed ---

Description:
A publicly-visible enum has a struct variant whose field is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/enum_struct_variant_field_missing.ron

Failed in:
  field init_field_slot of variant Origin::Borrowed, previously in file /tmp/.tmpnGMAun/shapely-core/src/partial.rs:8

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/inherent_method_missing.ron

Failed in:
  Slot::for_struct_field, previously in file /tmp/.tmpnGMAun/shapely-core/src/slot.rs:28
  Partial::slot, previously in file /tmp/.tmpnGMAun/shapely-core/src/partial.rs:181
  Partial::shape_desc, previously in file /tmp/.tmpnGMAun/shapely-core/src/partial.rs:286
  Partial::addr_for_display, previously in file /tmp/.tmpnGMAun/shapely-core/src/partial.rs:292
  Innards::static_fields, previously in file /tmp/.tmpnGMAun/shapely-core/src/shape.rs:179

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/method_parameter_count_changed.ron

Failed in:
  shapely_core::Slot::for_hash_map now takes 3 parameters instead of 4, in /tmp/.tmp0ovIur/shapely/shapely-core/src/slot.rs:44

--- failure type_mismatched_generic_lifetimes: type now takes a different number of generic lifetimes ---

Description:
A type now takes a different number of generic lifetime parameters. Uses of this type that name the previous number of parameters will be broken.
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/type_mismatched_generic_lifetimes.ron
Failed in:
  Struct Field (1 -> 0 lifetime params) in /tmp/.tmp0ovIur/shapely/shapely-core/src/shape.rs:268
```

### ⚠ `shapely` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/enum_missing.ron

Failed in:
  enum shapely::InitFieldSlot, previously in file /tmp/.tmpnGMAun/shapely/src/partial.rs:334
  enum shapely::Scalar, previously in file /tmp/.tmpnGMAun/shapely/src/shape.rs:224
  enum shapely::Innards, previously in file /tmp/.tmpnGMAun/shapely/src/shape.rs:166
  enum shapely::SetFieldOutcome, previously in file /tmp/.tmpnGMAun/shapely/src/shape.rs:214
  enum shapely::Origin, previously in file /tmp/.tmpnGMAun/shapely/src/partial.rs:5

--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/feature_missing.ron

Failed in:
  feature shapely-derive in the package's Cargo.toml
  feature derive in the package's Cargo.toml

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/function_missing.ron

Failed in:
  function shapely::mini_typeid::of, previously in file /tmp/.tmpnGMAun/shapely/src/mini_typeid.rs:11

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/module_missing.ron

Failed in:
  mod shapely::mini_typeid, previously in file /tmp/.tmpnGMAun/shapely/src/mini_typeid.rs:7

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/struct_missing.ron

Failed in:
  struct shapely::Slot, previously in file /tmp/.tmpnGMAun/shapely/src/slot.rs:15
  struct shapely::Partial, previously in file /tmp/.tmpnGMAun/shapely/src/partial.rs:14
  struct shapely::Shape, previously in file /tmp/.tmpnGMAun/shapely/src/shape.rs:7
  struct shapely::ShapeDesc, previously in file /tmp/.tmpnGMAun/shapely/src/shape.rs:261
  struct shapely::InitSet64, previously in file /tmp/.tmpnGMAun/shapely/src/partial.rs:307
  struct shapely::Field, previously in file /tmp/.tmpnGMAun/shapely/src/shape.rs:193

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/trait_missing.ron

Failed in:
  trait shapely::Shapely, previously in file /tmp/.tmpnGMAun/shapely/src/lib.rs:34
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `shapely-core`

<blockquote>

## [2.0.0](https://github.com/bearcove/shapely/compare/shapely-core-v1.0.0...shapely-core-v2.0.0) - 2025-03-11

### Other

- Stub out shapely-yaml
- Simplify Shape name function signature
- Clean up HashMap's name impl
- Change Shape.name from static str to NameFn
- Note on valid zst pointer values, closes #11
- Back to something working
- Clippy auto fix
- Add `addr` and `shape` methods to Partial and Slot
- Looking good!
- Refactor slot_by_name and move_into
- Refactor Partial struct initialization and field access
- more slot/field cleanups
- Clean up Partial API
- clean up drop impls
- more work on the field API
- Shape up field API
- Stability notes
- introduce slot_by_index / slot_by_name
- link to 'free of syn' campaign
- wip sloterrors
- Ensure no syn dependency (and badge about it), closes #9
</blockquote>

## `shapely-derive`

<blockquote>

## [2.0.0](https://github.com/bearcove/shapely/compare/shapely-derive-v1.0.0...shapely-derive-v2.0.0) - 2025-03-11

### Other

- Stub out shapely-yaml
- Simplify Shape name function signature
- Change Shape.name from static str to NameFn
- Stability notes
- link to 'free of syn' campaign
- Ensure no syn dependency (and badge about it), closes #9
- Introduce core crate
- Get rid of debug/display, closes #4
</blockquote>

## `shapely`

<blockquote>

## [2.0.0](https://github.com/bearcove/shapely/compare/shapely-v1.0.0...shapely-v2.0.0) - 2025-03-11

### Other

- Change Shape.name from static str to NameFn
- Looking good!
- clean up drop impls
- Stability notes
- link to 'free of syn' campaign
- Make derive unconditional, closes #8
- Get rid of insta, closes #10
- Ensure no syn dependency (and badge about it), closes #9
- Introduce core crate
- Get rid of debug/display, closes #4
- Start implementing transparent
</blockquote>

## `shapely-json`

<blockquote>

## [2.0.0](https://github.com/bearcove/shapely/compare/shapely-json-v1.0.0...shapely-json-v2.0.0) - 2025-03-11

### Other

- Simplify Shape name function signature
- Change Shape.name from static str to NameFn
- Back to something working
- Tests pass again
- Add `addr` and `shape` methods to Partial and Slot
- Looking good!
- Clean up Partial API
- Shape up field API
- Stability notes
- introduce slot_by_index / slot_by_name
- link to 'free of syn' campaign
- Ensure no syn dependency (and badge about it), closes #9
- Introduce core crate
- Get rid of debug/display, closes #4
</blockquote>

## `shapely-yaml`

<blockquote>

## [2.0.0](https://github.com/bearcove/shapely/compare/shapely-yaml-v1.0.0...shapely-yaml-v2.0.0) - 2025-03-11

### Other

- Stub out shapely-yaml
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).