### PR TITLE
chore: release v3.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ checksum = "b985e394ee53f8e4c547d5c6fa75b83b243ab6f51563a0323f1475fc8abc8e7f"
 
 [[package]]
 name = "shapely"
-version = "2.0.1"
+version = "3.0.0"
 dependencies = [
  "shapely-core",
  "shapely-derive",
@@ -93,11 +93,11 @@ dependencies = [
 
 [[package]]
 name = "shapely-core"
-version = "2.0.1"
+version = "3.0.0"
 
 [[package]]
 name = "shapely-derive"
-version = "2.0.1"
+version = "3.0.0"
 dependencies = [
  "shapely-core",
  "unsynn",
@@ -105,14 +105,14 @@ dependencies = [
 
 [[package]]
 name = "shapely-json"
-version = "2.0.1"
+version = "3.0.0"
 dependencies = [
  "shapely",
 ]
 
 [[package]]
 name = "shapely-msgpack"
-version = "2.0.1"
+version = "3.0.0"
 dependencies = [
  "shapely",
  "shapely-core",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "shapely-pretty"
-version = "2.0.1"
+version = "3.0.0"
 dependencies = [
  "shapely",
  "shapely-core",
@@ -129,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "shapely-urlencoded"
-version = "2.0.1"
+version = "3.0.0"
 dependencies = [
  "form_urlencoded",
  "shapely",
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "shapely-yaml"
-version = "2.0.1"
+version = "3.0.0"
 dependencies = [
  "shapely",
  "shapely-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["shapely", "shapely-core", "shapely-derive", "shapely-json", "shapely
 resolver = "3"
 
 [workspace.package]
-version = "2.0.1"
+version = "3.0.0"
 authors = ["Amos Wenger <amos@bearcove.eu>"]
 edition = "2024"
 rust-version = "1.85"
@@ -22,9 +22,9 @@ keywords = [
 categories = ["encoding", "parsing", "development-tools", "data-structures"]
 
 [workspace.dependencies]
-shapely = { version = "2.0.1", path = "shapely" }
-shapely-core = { version = "2.0.1", path = "shapely-core" }
-shapely-derive = { version = "2.0.1", path = "shapely-derive" }
-shapely-pretty = { version = "2.0.1", path = "shapely-pretty" }
+shapely = { version = "3.0.0", path = "shapely" }
+shapely-core = { version = "3.0.0", path = "shapely-core" }
+shapely-derive = { version = "3.0.0", path = "shapely-derive" }
+shapely-pretty = { version = "3.0.0", path = "shapely-pretty" }
 unsynn = "0.0.25"
 form_urlencoded = "1.2.1"

--- a/shapely-core/CHANGELOG.md
+++ b/shapely-core/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0](https://github.com/bearcove/shapely/compare/shapely-core-v2.0.1...shapely-core-v3.0.0) - 2025-03-11
+
+### Added
+
+- Add sensitive field support
+- Improve FieldFlags with const support
+
+### Other
+
+- warnings--
+- Remove unreachable wildcard pattern in ScalarContents::get_contents
+- non exhaustive
+- mh
+- Add scalar contents tests and improvements
+
 ## [2.0.0](https://github.com/bearcove/shapely/compare/shapely-core-v1.0.0...shapely-core-v2.0.0) - 2025-03-11
 
 ### Other

--- a/shapely-pretty/CHANGELOG.md
+++ b/shapely-pretty/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [3.0.0](https://github.com/bearcove/shapely/compare/shapely-pretty-v2.0.1...shapely-pretty-v3.0.0) - 2025-03-11
+
+### Added
+
+- Add sensitive field support
+
+### Other
+
+- warnings--
+- Sensitive fields are /actually/ redacted now
+- Improve sensitive fields test with actual data
+- Fix doc tests in README.md
+- wip
+- Use ScalarContents API to replace unsafe memory access in PrettyPrinter
+- mh
+- Introduce shapely-pretty

--- a/shapely/CHANGELOG.md
+++ b/shapely/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0](https://github.com/bearcove/shapely/compare/shapely-v2.0.1...shapely-v3.0.0) - 2025-03-11
+
+### Other
+
+- Fix doc tests in README.md
+- Document how to write your deserializer a little better
+
 ## [2.0.0](https://github.com/bearcove/shapely/compare/shapely-v1.0.0...shapely-v2.0.0) - 2025-03-11
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `shapely-core`: 2.0.1 -> 3.0.0 (⚠ API breaking changes)
* `shapely-derive`: 2.0.1 -> 3.0.0
* `shapely`: 2.0.1 -> 3.0.0 (✓ API compatible changes)
* `shapely-json`: 2.0.1 -> 3.0.0
* `shapely-msgpack`: 2.0.1 -> 3.0.0
* `shapely-pretty`: 2.0.1 -> 3.0.0
* `shapely-urlencoded`: 2.0.1 -> 3.0.0
* `shapely-yaml`: 2.0.1 -> 3.0.0

### ⚠ `shapely-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Field.flags in /tmp/.tmpbhVtE4/shapely/shapely-core/src/shape.rs:299
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `shapely-core`

<blockquote>

## [3.0.0](https://github.com/bearcove/shapely/compare/shapely-core-v2.0.1...shapely-core-v3.0.0) - 2025-03-11

### Added

- Add sensitive field support
- Improve FieldFlags with const support

### Other

- warnings--
- Remove unreachable wildcard pattern in ScalarContents::get_contents
- non exhaustive
- mh
- Add scalar contents tests and improvements
</blockquote>

## `shapely-derive`

<blockquote>

## [2.0.0](https://github.com/bearcove/shapely/compare/shapely-derive-v1.0.0...shapely-derive-v2.0.0) - 2025-03-11

### Other

- Stub out shapely-yaml
- Simplify Shape name function signature
- Change Shape.name from static str to NameFn
- Stability notes
- link to 'free of syn' campaign
- Ensure no syn dependency (and badge about it), closes #9
- Introduce core crate
- Get rid of debug/display, closes #4
</blockquote>

## `shapely`

<blockquote>

## [3.0.0](https://github.com/bearcove/shapely/compare/shapely-v2.0.1...shapely-v3.0.0) - 2025-03-11

### Other

- Fix doc tests in README.md
- Document how to write your deserializer a little better
</blockquote>

## `shapely-json`

<blockquote>

## [2.0.0](https://github.com/bearcove/shapely/compare/shapely-json-v1.0.0...shapely-json-v2.0.0) - 2025-03-11

### Other

- Simplify Shape name function signature
- Change Shape.name from static str to NameFn
- Back to something working
- Tests pass again
- Add `addr` and `shape` methods to Partial and Slot
- Looking good!
- Clean up Partial API
- Shape up field API
- Stability notes
- introduce slot_by_index / slot_by_name
- link to 'free of syn' campaign
- Ensure no syn dependency (and badge about it), closes #9
- Introduce core crate
- Get rid of debug/display, closes #4
</blockquote>

## `shapely-msgpack`

<blockquote>

## [2.0.1](https://github.com/bearcove/shapely/compare/shapely-msgpack-v2.0.0...shapely-msgpack-v2.0.1) - 2025-03-11

### Other

- Last few fixes
- Add examples to YAML and MessagePack crates, simplify READMEs, and fix doc tests
</blockquote>

## `shapely-pretty`

<blockquote>

## [3.0.0](https://github.com/bearcove/shapely/compare/shapely-pretty-v2.0.1...shapely-pretty-v3.0.0) - 2025-03-11

### Added

- Add sensitive field support

### Other

- warnings--
- Sensitive fields are /actually/ redacted now
- Improve sensitive fields test with actual data
- Fix doc tests in README.md
- wip
- Use ScalarContents API to replace unsafe memory access in PrettyPrinter
- mh
- Introduce shapely-pretty
</blockquote>

## `shapely-urlencoded`

<blockquote>

## [2.0.1](https://github.com/bearcove/shapely/compare/shapely-urlencoded-v2.0.0...shapely-urlencoded-v2.0.1) - 2025-03-11

### Other

- Last few fixes
- Add shapely-urlencoded crate for URL encoded form data deserialization
</blockquote>

## `shapely-yaml`

<blockquote>

## [2.0.1](https://github.com/bearcove/shapely/compare/shapely-yaml-v2.0.0...shapely-yaml-v2.0.1) - 2025-03-11

### Other

- Add examples to YAML and MessagePack crates, simplify READMEs, and fix doc tests
- Clippy fixes
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).