### PR TITLE
Use trick by @veykril to reduce codegen size

### DIFF
--- a/shapely-codegen/src/main.rs
+++ b/shapely-codegen/src/main.rs
@@ -38,48 +38,53 @@ fn codegen_tuple_impls(w: &mut dyn Write) -> std::fmt::Result {
 
     // Generate implementations for tuples of size 1 to 12
     for n in 1..=12 {
-        let type_params = (1..=n)
+        let type_params = (0..n)
             .map(|i| format!("T{}", i))
             .collect::<Vec<_>>()
             .join(", ");
 
-        let fields = (0..n)
-            .map(|i| {
-                format!(
-                    "Field {{
-                name: \"{}\",
-                shape: ShapeDesc(T{}::shape),
-                offset: std::mem::offset_of!(({},), {}),
-                flags: FieldFlags::EMPTY,
-            }}",
-                    i,
-                    i + 1,
-                    type_params,
-                    i
-                )
-            })
-            .collect::<Vec<_>>()
-            .join(", ");
-
         let mut name_format = "write!(f, \"(\")?;".to_string();
-        for i in 1..=n {
+        for i in 0..n {
             name_format += &format!("\n                (T{}::shape().name)(f)?;", i);
-            if i < n {
+            if i < n - 1 {
                 name_format += "\n                write!(f, \",\")?;";
             }
         }
         name_format += "\n                write!(f, \",)\")";
 
-        let where_clause = (1..=n)
+        let where_clause = (0..n)
             .map(|i| format!("T{}: Shapely", i))
             .collect::<Vec<_>>()
             .join(", ");
 
         let tuple = if n == 1 {
-            "(T1,)".to_string()
+            "(T0,)".to_string()
         } else {
             format!("({})", type_params)
         };
+
+        let field_macro = format!(
+            r#"
+        macro_rules! field {{
+            ($idx:tt, $ty:ty) => {{
+                Field {{
+                    name: stringify!($idx),
+                    shape: ShapeDesc(<$ty>::shape),
+                    offset: std::mem::offset_of!({tuple}, $idx),
+                    flags: FieldFlags::EMPTY,
+                }}
+            }}
+        }}
+        "#
+        );
+
+        let fields = format!(
+            "&const {{ [ {} ] }}",
+            (0..n)
+                .map(|i| format!("field!({}, T{})", i, i))
+                .collect::<Vec<_>>()
+                .join(",")
+        );
 
         writeln!(
             w,
@@ -87,15 +92,7 @@ fn codegen_tuple_impls(w: &mut dyn Write) -> std::fmt::Result {
             impl<{type_params}> Shapely for {tuple} where {where_clause}
             {{
                 fn shape() -> Shape {{
-                    struct FieldsMaker<{type_params}> {{
-                        #[allow(clippy::type_complexity)]
-                        _phantom: std::marker::PhantomData<{tuple}>,
-                    }}
-
-                    impl<{type_params}> FieldsMaker<{type_params}> where {where_clause}
-                    {{
-                        const FIELDS: [Field; {n}] = [{fields}];
-                    }}
+                    {field_macro}
 
                     Shape {{
                         name: |f| {{
@@ -104,7 +101,7 @@ fn codegen_tuple_impls(w: &mut dyn Write) -> std::fmt::Result {
                         typeid: mini_typeid::of::<Self>(),
                         layout: Layout::new::<{tuple}>(),
                         innards: Innards::Tuple {{
-                            fields: &FieldsMaker::<{type_params}>::FIELDS,
+                            fields: {fields}
                         }},
                         set_to_default: None,
                         drop_in_place: Some(|addr: *mut u8| unsafe {{

--- a/shapely-core/src/tuples_impls.rs
+++ b/shapely-core/src/tuples_impls.rs
@@ -2,143 +2,144 @@ use std::alloc::Layout;
 
 use crate::{Field, FieldFlags, Innards, Shape, ShapeDesc, Shapely, mini_typeid};
 
-impl<T1> Shapely for (T1,)
+impl<T0> Shapely for (T0,)
 where
-    T1: Shapely,
+    T0: Shapely,
 {
     fn shape() -> Shape {
-        struct FieldsMaker<T1> {
-            #[allow(clippy::type_complexity)]
-            _phantom: std::marker::PhantomData<(T1,)>,
-        }
-
-        impl<T1> FieldsMaker<T1>
-        where
-            T1: Shapely,
-        {
-            const FIELDS: [Field; 1] = [Field {
-                name: "0",
-                shape: ShapeDesc(T1::shape),
-                offset: std::mem::offset_of!((T1,), 0),
-                flags: FieldFlags::EMPTY,
-            }];
+        macro_rules! field {
+            ($idx:tt, $ty:ty) => {
+                Field {
+                    name: stringify!($idx),
+                    shape: ShapeDesc(<$ty>::shape),
+                    offset: std::mem::offset_of!((T0,), $idx),
+                    flags: FieldFlags::EMPTY,
+                }
+            };
         }
 
         Shape {
             name: |f| {
                 write!(f, "(")?;
-                (T1::shape().name)(f)?;
+                (T0::shape().name)(f)?;
                 write!(f, ",)")
             },
             typeid: mini_typeid::of::<Self>(),
-            layout: Layout::new::<(T1,)>(),
+            layout: Layout::new::<(T0,)>(),
             innards: Innards::Tuple {
-                fields: &FieldsMaker::<T1>::FIELDS,
+                fields: &const { [field!(0, T0)] },
             },
             set_to_default: None,
             drop_in_place: Some(|addr: *mut u8| unsafe {
-                std::ptr::drop_in_place(addr as *mut (T1,));
+                std::ptr::drop_in_place(addr as *mut (T0,));
             }),
         }
     }
 }
 
-impl<T1, T2> Shapely for (T1, T2)
+impl<T0, T1> Shapely for (T0, T1)
 where
+    T0: Shapely,
     T1: Shapely,
-    T2: Shapely,
 {
     fn shape() -> Shape {
-        struct FieldsMaker<T1, T2> {
-            #[allow(clippy::type_complexity)]
-            _phantom: std::marker::PhantomData<(T1, T2)>,
-        }
-
-        impl<T1, T2> FieldsMaker<T1, T2>
-        where
-            T1: Shapely,
-            T2: Shapely,
-        {
-            const FIELDS: [Field; 2] = [
+        macro_rules! field {
+            ($idx:tt, $ty:ty) => {
                 Field {
-                    name: "0",
-                    shape: ShapeDesc(T1::shape),
-                    offset: std::mem::offset_of!((T1, T2,), 0),
+                    name: stringify!($idx),
+                    shape: ShapeDesc(<$ty>::shape),
+                    offset: std::mem::offset_of!((T0, T1), $idx),
                     flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "1",
-                    shape: ShapeDesc(T2::shape),
-                    offset: std::mem::offset_of!((T1, T2,), 1),
-                    flags: FieldFlags::EMPTY,
-                },
-            ];
+                }
+            };
         }
 
         Shape {
             name: |f| {
                 write!(f, "(")?;
+                (T0::shape().name)(f)?;
+                write!(f, ",")?;
+                (T1::shape().name)(f)?;
+                write!(f, ",)")
+            },
+            typeid: mini_typeid::of::<Self>(),
+            layout: Layout::new::<(T0, T1)>(),
+            innards: Innards::Tuple {
+                fields: &const { [field!(0, T0), field!(1, T1)] },
+            },
+            set_to_default: None,
+            drop_in_place: Some(|addr: *mut u8| unsafe {
+                std::ptr::drop_in_place(addr as *mut (T0, T1));
+            }),
+        }
+    }
+}
+
+impl<T0, T1, T2> Shapely for (T0, T1, T2)
+where
+    T0: Shapely,
+    T1: Shapely,
+    T2: Shapely,
+{
+    fn shape() -> Shape {
+        macro_rules! field {
+            ($idx:tt, $ty:ty) => {
+                Field {
+                    name: stringify!($idx),
+                    shape: ShapeDesc(<$ty>::shape),
+                    offset: std::mem::offset_of!((T0, T1, T2), $idx),
+                    flags: FieldFlags::EMPTY,
+                }
+            };
+        }
+
+        Shape {
+            name: |f| {
+                write!(f, "(")?;
+                (T0::shape().name)(f)?;
+                write!(f, ",")?;
                 (T1::shape().name)(f)?;
                 write!(f, ",")?;
                 (T2::shape().name)(f)?;
                 write!(f, ",)")
             },
             typeid: mini_typeid::of::<Self>(),
-            layout: Layout::new::<(T1, T2)>(),
+            layout: Layout::new::<(T0, T1, T2)>(),
             innards: Innards::Tuple {
-                fields: &FieldsMaker::<T1, T2>::FIELDS,
+                fields: &const { [field!(0, T0), field!(1, T1), field!(2, T2)] },
             },
             set_to_default: None,
             drop_in_place: Some(|addr: *mut u8| unsafe {
-                std::ptr::drop_in_place(addr as *mut (T1, T2));
+                std::ptr::drop_in_place(addr as *mut (T0, T1, T2));
             }),
         }
     }
 }
 
-impl<T1, T2, T3> Shapely for (T1, T2, T3)
+impl<T0, T1, T2, T3> Shapely for (T0, T1, T2, T3)
 where
+    T0: Shapely,
     T1: Shapely,
     T2: Shapely,
     T3: Shapely,
 {
     fn shape() -> Shape {
-        struct FieldsMaker<T1, T2, T3> {
-            #[allow(clippy::type_complexity)]
-            _phantom: std::marker::PhantomData<(T1, T2, T3)>,
-        }
-
-        impl<T1, T2, T3> FieldsMaker<T1, T2, T3>
-        where
-            T1: Shapely,
-            T2: Shapely,
-            T3: Shapely,
-        {
-            const FIELDS: [Field; 3] = [
+        macro_rules! field {
+            ($idx:tt, $ty:ty) => {
                 Field {
-                    name: "0",
-                    shape: ShapeDesc(T1::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3,), 0),
+                    name: stringify!($idx),
+                    shape: ShapeDesc(<$ty>::shape),
+                    offset: std::mem::offset_of!((T0, T1, T2, T3), $idx),
                     flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "1",
-                    shape: ShapeDesc(T2::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3,), 1),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "2",
-                    shape: ShapeDesc(T3::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3,), 2),
-                    flags: FieldFlags::EMPTY,
-                },
-            ];
+                }
+            };
         }
 
         Shape {
             name: |f| {
                 write!(f, "(")?;
+                (T0::shape().name)(f)?;
+                write!(f, ",")?;
                 (T1::shape().name)(f)?;
                 write!(f, ",")?;
                 (T2::shape().name)(f)?;
@@ -147,69 +148,43 @@ where
                 write!(f, ",)")
             },
             typeid: mini_typeid::of::<Self>(),
-            layout: Layout::new::<(T1, T2, T3)>(),
+            layout: Layout::new::<(T0, T1, T2, T3)>(),
             innards: Innards::Tuple {
-                fields: &FieldsMaker::<T1, T2, T3>::FIELDS,
+                fields: &const { [field!(0, T0), field!(1, T1), field!(2, T2), field!(3, T3)] },
             },
             set_to_default: None,
             drop_in_place: Some(|addr: *mut u8| unsafe {
-                std::ptr::drop_in_place(addr as *mut (T1, T2, T3));
+                std::ptr::drop_in_place(addr as *mut (T0, T1, T2, T3));
             }),
         }
     }
 }
 
-impl<T1, T2, T3, T4> Shapely for (T1, T2, T3, T4)
+impl<T0, T1, T2, T3, T4> Shapely for (T0, T1, T2, T3, T4)
 where
+    T0: Shapely,
     T1: Shapely,
     T2: Shapely,
     T3: Shapely,
     T4: Shapely,
 {
     fn shape() -> Shape {
-        struct FieldsMaker<T1, T2, T3, T4> {
-            #[allow(clippy::type_complexity)]
-            _phantom: std::marker::PhantomData<(T1, T2, T3, T4)>,
-        }
-
-        impl<T1, T2, T3, T4> FieldsMaker<T1, T2, T3, T4>
-        where
-            T1: Shapely,
-            T2: Shapely,
-            T3: Shapely,
-            T4: Shapely,
-        {
-            const FIELDS: [Field; 4] = [
+        macro_rules! field {
+            ($idx:tt, $ty:ty) => {
                 Field {
-                    name: "0",
-                    shape: ShapeDesc(T1::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4,), 0),
+                    name: stringify!($idx),
+                    shape: ShapeDesc(<$ty>::shape),
+                    offset: std::mem::offset_of!((T0, T1, T2, T3, T4), $idx),
                     flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "1",
-                    shape: ShapeDesc(T2::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4,), 1),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "2",
-                    shape: ShapeDesc(T3::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4,), 2),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "3",
-                    shape: ShapeDesc(T4::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4,), 3),
-                    flags: FieldFlags::EMPTY,
-                },
-            ];
+                }
+            };
         }
 
         Shape {
             name: |f| {
                 write!(f, "(")?;
+                (T0::shape().name)(f)?;
+                write!(f, ",")?;
                 (T1::shape().name)(f)?;
                 write!(f, ",")?;
                 (T2::shape().name)(f)?;
@@ -220,20 +195,29 @@ where
                 write!(f, ",)")
             },
             typeid: mini_typeid::of::<Self>(),
-            layout: Layout::new::<(T1, T2, T3, T4)>(),
+            layout: Layout::new::<(T0, T1, T2, T3, T4)>(),
             innards: Innards::Tuple {
-                fields: &FieldsMaker::<T1, T2, T3, T4>::FIELDS,
+                fields: &const {
+                    [
+                        field!(0, T0),
+                        field!(1, T1),
+                        field!(2, T2),
+                        field!(3, T3),
+                        field!(4, T4),
+                    ]
+                },
             },
             set_to_default: None,
             drop_in_place: Some(|addr: *mut u8| unsafe {
-                std::ptr::drop_in_place(addr as *mut (T1, T2, T3, T4));
+                std::ptr::drop_in_place(addr as *mut (T0, T1, T2, T3, T4));
             }),
         }
     }
 }
 
-impl<T1, T2, T3, T4, T5> Shapely for (T1, T2, T3, T4, T5)
+impl<T0, T1, T2, T3, T4, T5> Shapely for (T0, T1, T2, T3, T4, T5)
 where
+    T0: Shapely,
     T1: Shapely,
     T2: Shapely,
     T3: Shapely,
@@ -241,56 +225,22 @@ where
     T5: Shapely,
 {
     fn shape() -> Shape {
-        struct FieldsMaker<T1, T2, T3, T4, T5> {
-            #[allow(clippy::type_complexity)]
-            _phantom: std::marker::PhantomData<(T1, T2, T3, T4, T5)>,
-        }
-
-        impl<T1, T2, T3, T4, T5> FieldsMaker<T1, T2, T3, T4, T5>
-        where
-            T1: Shapely,
-            T2: Shapely,
-            T3: Shapely,
-            T4: Shapely,
-            T5: Shapely,
-        {
-            const FIELDS: [Field; 5] = [
+        macro_rules! field {
+            ($idx:tt, $ty:ty) => {
                 Field {
-                    name: "0",
-                    shape: ShapeDesc(T1::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5,), 0),
+                    name: stringify!($idx),
+                    shape: ShapeDesc(<$ty>::shape),
+                    offset: std::mem::offset_of!((T0, T1, T2, T3, T4, T5), $idx),
                     flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "1",
-                    shape: ShapeDesc(T2::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5,), 1),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "2",
-                    shape: ShapeDesc(T3::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5,), 2),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "3",
-                    shape: ShapeDesc(T4::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5,), 3),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "4",
-                    shape: ShapeDesc(T5::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5,), 4),
-                    flags: FieldFlags::EMPTY,
-                },
-            ];
+                }
+            };
         }
 
         Shape {
             name: |f| {
                 write!(f, "(")?;
+                (T0::shape().name)(f)?;
+                write!(f, ",")?;
                 (T1::shape().name)(f)?;
                 write!(f, ",")?;
                 (T2::shape().name)(f)?;
@@ -303,20 +253,30 @@ where
                 write!(f, ",)")
             },
             typeid: mini_typeid::of::<Self>(),
-            layout: Layout::new::<(T1, T2, T3, T4, T5)>(),
+            layout: Layout::new::<(T0, T1, T2, T3, T4, T5)>(),
             innards: Innards::Tuple {
-                fields: &FieldsMaker::<T1, T2, T3, T4, T5>::FIELDS,
+                fields: &const {
+                    [
+                        field!(0, T0),
+                        field!(1, T1),
+                        field!(2, T2),
+                        field!(3, T3),
+                        field!(4, T4),
+                        field!(5, T5),
+                    ]
+                },
             },
             set_to_default: None,
             drop_in_place: Some(|addr: *mut u8| unsafe {
-                std::ptr::drop_in_place(addr as *mut (T1, T2, T3, T4, T5));
+                std::ptr::drop_in_place(addr as *mut (T0, T1, T2, T3, T4, T5));
             }),
         }
     }
 }
 
-impl<T1, T2, T3, T4, T5, T6> Shapely for (T1, T2, T3, T4, T5, T6)
+impl<T0, T1, T2, T3, T4, T5, T6> Shapely for (T0, T1, T2, T3, T4, T5, T6)
 where
+    T0: Shapely,
     T1: Shapely,
     T2: Shapely,
     T3: Shapely,
@@ -325,63 +285,22 @@ where
     T6: Shapely,
 {
     fn shape() -> Shape {
-        struct FieldsMaker<T1, T2, T3, T4, T5, T6> {
-            #[allow(clippy::type_complexity)]
-            _phantom: std::marker::PhantomData<(T1, T2, T3, T4, T5, T6)>,
-        }
-
-        impl<T1, T2, T3, T4, T5, T6> FieldsMaker<T1, T2, T3, T4, T5, T6>
-        where
-            T1: Shapely,
-            T2: Shapely,
-            T3: Shapely,
-            T4: Shapely,
-            T5: Shapely,
-            T6: Shapely,
-        {
-            const FIELDS: [Field; 6] = [
+        macro_rules! field {
+            ($idx:tt, $ty:ty) => {
                 Field {
-                    name: "0",
-                    shape: ShapeDesc(T1::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6,), 0),
+                    name: stringify!($idx),
+                    shape: ShapeDesc(<$ty>::shape),
+                    offset: std::mem::offset_of!((T0, T1, T2, T3, T4, T5, T6), $idx),
                     flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "1",
-                    shape: ShapeDesc(T2::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6,), 1),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "2",
-                    shape: ShapeDesc(T3::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6,), 2),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "3",
-                    shape: ShapeDesc(T4::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6,), 3),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "4",
-                    shape: ShapeDesc(T5::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6,), 4),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "5",
-                    shape: ShapeDesc(T6::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6,), 5),
-                    flags: FieldFlags::EMPTY,
-                },
-            ];
+                }
+            };
         }
 
         Shape {
             name: |f| {
                 write!(f, "(")?;
+                (T0::shape().name)(f)?;
+                write!(f, ",")?;
                 (T1::shape().name)(f)?;
                 write!(f, ",")?;
                 (T2::shape().name)(f)?;
@@ -396,20 +315,31 @@ where
                 write!(f, ",)")
             },
             typeid: mini_typeid::of::<Self>(),
-            layout: Layout::new::<(T1, T2, T3, T4, T5, T6)>(),
+            layout: Layout::new::<(T0, T1, T2, T3, T4, T5, T6)>(),
             innards: Innards::Tuple {
-                fields: &FieldsMaker::<T1, T2, T3, T4, T5, T6>::FIELDS,
+                fields: &const {
+                    [
+                        field!(0, T0),
+                        field!(1, T1),
+                        field!(2, T2),
+                        field!(3, T3),
+                        field!(4, T4),
+                        field!(5, T5),
+                        field!(6, T6),
+                    ]
+                },
             },
             set_to_default: None,
             drop_in_place: Some(|addr: *mut u8| unsafe {
-                std::ptr::drop_in_place(addr as *mut (T1, T2, T3, T4, T5, T6));
+                std::ptr::drop_in_place(addr as *mut (T0, T1, T2, T3, T4, T5, T6));
             }),
         }
     }
 }
 
-impl<T1, T2, T3, T4, T5, T6, T7> Shapely for (T1, T2, T3, T4, T5, T6, T7)
+impl<T0, T1, T2, T3, T4, T5, T6, T7> Shapely for (T0, T1, T2, T3, T4, T5, T6, T7)
 where
+    T0: Shapely,
     T1: Shapely,
     T2: Shapely,
     T3: Shapely,
@@ -419,70 +349,22 @@ where
     T7: Shapely,
 {
     fn shape() -> Shape {
-        struct FieldsMaker<T1, T2, T3, T4, T5, T6, T7> {
-            #[allow(clippy::type_complexity)]
-            _phantom: std::marker::PhantomData<(T1, T2, T3, T4, T5, T6, T7)>,
-        }
-
-        impl<T1, T2, T3, T4, T5, T6, T7> FieldsMaker<T1, T2, T3, T4, T5, T6, T7>
-        where
-            T1: Shapely,
-            T2: Shapely,
-            T3: Shapely,
-            T4: Shapely,
-            T5: Shapely,
-            T6: Shapely,
-            T7: Shapely,
-        {
-            const FIELDS: [Field; 7] = [
+        macro_rules! field {
+            ($idx:tt, $ty:ty) => {
                 Field {
-                    name: "0",
-                    shape: ShapeDesc(T1::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6, T7,), 0),
+                    name: stringify!($idx),
+                    shape: ShapeDesc(<$ty>::shape),
+                    offset: std::mem::offset_of!((T0, T1, T2, T3, T4, T5, T6, T7), $idx),
                     flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "1",
-                    shape: ShapeDesc(T2::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6, T7,), 1),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "2",
-                    shape: ShapeDesc(T3::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6, T7,), 2),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "3",
-                    shape: ShapeDesc(T4::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6, T7,), 3),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "4",
-                    shape: ShapeDesc(T5::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6, T7,), 4),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "5",
-                    shape: ShapeDesc(T6::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6, T7,), 5),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "6",
-                    shape: ShapeDesc(T7::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6, T7,), 6),
-                    flags: FieldFlags::EMPTY,
-                },
-            ];
+                }
+            };
         }
 
         Shape {
             name: |f| {
                 write!(f, "(")?;
+                (T0::shape().name)(f)?;
+                write!(f, ",")?;
                 (T1::shape().name)(f)?;
                 write!(f, ",")?;
                 (T2::shape().name)(f)?;
@@ -499,20 +381,32 @@ where
                 write!(f, ",)")
             },
             typeid: mini_typeid::of::<Self>(),
-            layout: Layout::new::<(T1, T2, T3, T4, T5, T6, T7)>(),
+            layout: Layout::new::<(T0, T1, T2, T3, T4, T5, T6, T7)>(),
             innards: Innards::Tuple {
-                fields: &FieldsMaker::<T1, T2, T3, T4, T5, T6, T7>::FIELDS,
+                fields: &const {
+                    [
+                        field!(0, T0),
+                        field!(1, T1),
+                        field!(2, T2),
+                        field!(3, T3),
+                        field!(4, T4),
+                        field!(5, T5),
+                        field!(6, T6),
+                        field!(7, T7),
+                    ]
+                },
             },
             set_to_default: None,
             drop_in_place: Some(|addr: *mut u8| unsafe {
-                std::ptr::drop_in_place(addr as *mut (T1, T2, T3, T4, T5, T6, T7));
+                std::ptr::drop_in_place(addr as *mut (T0, T1, T2, T3, T4, T5, T6, T7));
             }),
         }
     }
 }
 
-impl<T1, T2, T3, T4, T5, T6, T7, T8> Shapely for (T1, T2, T3, T4, T5, T6, T7, T8)
+impl<T0, T1, T2, T3, T4, T5, T6, T7, T8> Shapely for (T0, T1, T2, T3, T4, T5, T6, T7, T8)
 where
+    T0: Shapely,
     T1: Shapely,
     T2: Shapely,
     T3: Shapely,
@@ -523,77 +417,22 @@ where
     T8: Shapely,
 {
     fn shape() -> Shape {
-        struct FieldsMaker<T1, T2, T3, T4, T5, T6, T7, T8> {
-            #[allow(clippy::type_complexity)]
-            _phantom: std::marker::PhantomData<(T1, T2, T3, T4, T5, T6, T7, T8)>,
-        }
-
-        impl<T1, T2, T3, T4, T5, T6, T7, T8> FieldsMaker<T1, T2, T3, T4, T5, T6, T7, T8>
-        where
-            T1: Shapely,
-            T2: Shapely,
-            T3: Shapely,
-            T4: Shapely,
-            T5: Shapely,
-            T6: Shapely,
-            T7: Shapely,
-            T8: Shapely,
-        {
-            const FIELDS: [Field; 8] = [
+        macro_rules! field {
+            ($idx:tt, $ty:ty) => {
                 Field {
-                    name: "0",
-                    shape: ShapeDesc(T1::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6, T7, T8,), 0),
+                    name: stringify!($idx),
+                    shape: ShapeDesc(<$ty>::shape),
+                    offset: std::mem::offset_of!((T0, T1, T2, T3, T4, T5, T6, T7, T8), $idx),
                     flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "1",
-                    shape: ShapeDesc(T2::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6, T7, T8,), 1),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "2",
-                    shape: ShapeDesc(T3::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6, T7, T8,), 2),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "3",
-                    shape: ShapeDesc(T4::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6, T7, T8,), 3),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "4",
-                    shape: ShapeDesc(T5::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6, T7, T8,), 4),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "5",
-                    shape: ShapeDesc(T6::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6, T7, T8,), 5),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "6",
-                    shape: ShapeDesc(T7::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6, T7, T8,), 6),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "7",
-                    shape: ShapeDesc(T8::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6, T7, T8,), 7),
-                    flags: FieldFlags::EMPTY,
-                },
-            ];
+                }
+            };
         }
 
         Shape {
             name: |f| {
                 write!(f, "(")?;
+                (T0::shape().name)(f)?;
+                write!(f, ",")?;
                 (T1::shape().name)(f)?;
                 write!(f, ",")?;
                 (T2::shape().name)(f)?;
@@ -612,20 +451,33 @@ where
                 write!(f, ",)")
             },
             typeid: mini_typeid::of::<Self>(),
-            layout: Layout::new::<(T1, T2, T3, T4, T5, T6, T7, T8)>(),
+            layout: Layout::new::<(T0, T1, T2, T3, T4, T5, T6, T7, T8)>(),
             innards: Innards::Tuple {
-                fields: &FieldsMaker::<T1, T2, T3, T4, T5, T6, T7, T8>::FIELDS,
+                fields: &const {
+                    [
+                        field!(0, T0),
+                        field!(1, T1),
+                        field!(2, T2),
+                        field!(3, T3),
+                        field!(4, T4),
+                        field!(5, T5),
+                        field!(6, T6),
+                        field!(7, T7),
+                        field!(8, T8),
+                    ]
+                },
             },
             set_to_default: None,
             drop_in_place: Some(|addr: *mut u8| unsafe {
-                std::ptr::drop_in_place(addr as *mut (T1, T2, T3, T4, T5, T6, T7, T8));
+                std::ptr::drop_in_place(addr as *mut (T0, T1, T2, T3, T4, T5, T6, T7, T8));
             }),
         }
     }
 }
 
-impl<T1, T2, T3, T4, T5, T6, T7, T8, T9> Shapely for (T1, T2, T3, T4, T5, T6, T7, T8, T9)
+impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Shapely for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)
 where
+    T0: Shapely,
     T1: Shapely,
     T2: Shapely,
     T3: Shapely,
@@ -637,84 +489,22 @@ where
     T9: Shapely,
 {
     fn shape() -> Shape {
-        struct FieldsMaker<T1, T2, T3, T4, T5, T6, T7, T8, T9> {
-            #[allow(clippy::type_complexity)]
-            _phantom: std::marker::PhantomData<(T1, T2, T3, T4, T5, T6, T7, T8, T9)>,
-        }
-
-        impl<T1, T2, T3, T4, T5, T6, T7, T8, T9> FieldsMaker<T1, T2, T3, T4, T5, T6, T7, T8, T9>
-        where
-            T1: Shapely,
-            T2: Shapely,
-            T3: Shapely,
-            T4: Shapely,
-            T5: Shapely,
-            T6: Shapely,
-            T7: Shapely,
-            T8: Shapely,
-            T9: Shapely,
-        {
-            const FIELDS: [Field; 9] = [
+        macro_rules! field {
+            ($idx:tt, $ty:ty) => {
                 Field {
-                    name: "0",
-                    shape: ShapeDesc(T1::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6, T7, T8, T9,), 0),
+                    name: stringify!($idx),
+                    shape: ShapeDesc(<$ty>::shape),
+                    offset: std::mem::offset_of!((T0, T1, T2, T3, T4, T5, T6, T7, T8, T9), $idx),
                     flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "1",
-                    shape: ShapeDesc(T2::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6, T7, T8, T9,), 1),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "2",
-                    shape: ShapeDesc(T3::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6, T7, T8, T9,), 2),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "3",
-                    shape: ShapeDesc(T4::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6, T7, T8, T9,), 3),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "4",
-                    shape: ShapeDesc(T5::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6, T7, T8, T9,), 4),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "5",
-                    shape: ShapeDesc(T6::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6, T7, T8, T9,), 5),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "6",
-                    shape: ShapeDesc(T7::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6, T7, T8, T9,), 6),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "7",
-                    shape: ShapeDesc(T8::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6, T7, T8, T9,), 7),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "8",
-                    shape: ShapeDesc(T9::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6, T7, T8, T9,), 8),
-                    flags: FieldFlags::EMPTY,
-                },
-            ];
+                }
+            };
         }
 
         Shape {
             name: |f| {
                 write!(f, "(")?;
+                (T0::shape().name)(f)?;
+                write!(f, ",")?;
                 (T1::shape().name)(f)?;
                 write!(f, ",")?;
                 (T2::shape().name)(f)?;
@@ -735,20 +525,35 @@ where
                 write!(f, ",)")
             },
             typeid: mini_typeid::of::<Self>(),
-            layout: Layout::new::<(T1, T2, T3, T4, T5, T6, T7, T8, T9)>(),
+            layout: Layout::new::<(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)>(),
             innards: Innards::Tuple {
-                fields: &FieldsMaker::<T1, T2, T3, T4, T5, T6, T7, T8, T9>::FIELDS,
+                fields: &const {
+                    [
+                        field!(0, T0),
+                        field!(1, T1),
+                        field!(2, T2),
+                        field!(3, T3),
+                        field!(4, T4),
+                        field!(5, T5),
+                        field!(6, T6),
+                        field!(7, T7),
+                        field!(8, T8),
+                        field!(9, T9),
+                    ]
+                },
             },
             set_to_default: None,
             drop_in_place: Some(|addr: *mut u8| unsafe {
-                std::ptr::drop_in_place(addr as *mut (T1, T2, T3, T4, T5, T6, T7, T8, T9));
+                std::ptr::drop_in_place(addr as *mut (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9));
             }),
         }
     }
 }
 
-impl<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Shapely for (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Shapely
+    for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
 where
+    T0: Shapely,
     T1: Shapely,
     T2: Shapely,
     T3: Shapely,
@@ -761,91 +566,25 @@ where
     T10: Shapely,
 {
     fn shape() -> Shape {
-        struct FieldsMaker<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> {
-            #[allow(clippy::type_complexity)]
-            _phantom: std::marker::PhantomData<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)>,
-        }
-
-        impl<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> FieldsMaker<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>
-        where
-            T1: Shapely,
-            T2: Shapely,
-            T3: Shapely,
-            T4: Shapely,
-            T5: Shapely,
-            T6: Shapely,
-            T7: Shapely,
-            T8: Shapely,
-            T9: Shapely,
-            T10: Shapely,
-        {
-            const FIELDS: [Field; 10] = [
+        macro_rules! field {
+            ($idx:tt, $ty:ty) => {
                 Field {
-                    name: "0",
-                    shape: ShapeDesc(T1::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6, T7, T8, T9, T10,), 0),
+                    name: stringify!($idx),
+                    shape: ShapeDesc(<$ty>::shape),
+                    offset: std::mem::offset_of!(
+                        (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10),
+                        $idx
+                    ),
                     flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "1",
-                    shape: ShapeDesc(T2::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6, T7, T8, T9, T10,), 1),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "2",
-                    shape: ShapeDesc(T3::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6, T7, T8, T9, T10,), 2),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "3",
-                    shape: ShapeDesc(T4::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6, T7, T8, T9, T10,), 3),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "4",
-                    shape: ShapeDesc(T5::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6, T7, T8, T9, T10,), 4),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "5",
-                    shape: ShapeDesc(T6::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6, T7, T8, T9, T10,), 5),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "6",
-                    shape: ShapeDesc(T7::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6, T7, T8, T9, T10,), 6),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "7",
-                    shape: ShapeDesc(T8::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6, T7, T8, T9, T10,), 7),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "8",
-                    shape: ShapeDesc(T9::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6, T7, T8, T9, T10,), 8),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "9",
-                    shape: ShapeDesc(T10::shape),
-                    offset: std::mem::offset_of!((T1, T2, T3, T4, T5, T6, T7, T8, T9, T10,), 9),
-                    flags: FieldFlags::EMPTY,
-                },
-            ];
+                }
+            };
         }
 
         Shape {
             name: |f| {
                 write!(f, "(")?;
+                (T0::shape().name)(f)?;
+                write!(f, ",")?;
                 (T1::shape().name)(f)?;
                 write!(f, ",")?;
                 (T2::shape().name)(f)?;
@@ -868,21 +607,36 @@ where
                 write!(f, ",)")
             },
             typeid: mini_typeid::of::<Self>(),
-            layout: Layout::new::<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)>(),
+            layout: Layout::new::<(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)>(),
             innards: Innards::Tuple {
-                fields: &FieldsMaker::<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>::FIELDS,
+                fields: &const {
+                    [
+                        field!(0, T0),
+                        field!(1, T1),
+                        field!(2, T2),
+                        field!(3, T3),
+                        field!(4, T4),
+                        field!(5, T5),
+                        field!(6, T6),
+                        field!(7, T7),
+                        field!(8, T8),
+                        field!(9, T9),
+                        field!(10, T10),
+                    ]
+                },
             },
             set_to_default: None,
             drop_in_place: Some(|addr: *mut u8| unsafe {
-                std::ptr::drop_in_place(addr as *mut (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10));
+                std::ptr::drop_in_place(addr as *mut (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10));
             }),
         }
     }
 }
 
-impl<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Shapely
-    for (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+impl<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Shapely
+    for (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
 where
+    T0: Shapely,
     T1: Shapely,
     T2: Shapely,
     T3: Shapely,
@@ -896,132 +650,25 @@ where
     T11: Shapely,
 {
     fn shape() -> Shape {
-        struct FieldsMaker<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> {
-            #[allow(clippy::type_complexity)]
-            _phantom: std::marker::PhantomData<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)>,
-        }
-
-        impl<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>
-            FieldsMaker<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>
-        where
-            T1: Shapely,
-            T2: Shapely,
-            T3: Shapely,
-            T4: Shapely,
-            T5: Shapely,
-            T6: Shapely,
-            T7: Shapely,
-            T8: Shapely,
-            T9: Shapely,
-            T10: Shapely,
-            T11: Shapely,
-        {
-            const FIELDS: [Field; 11] = [
+        macro_rules! field {
+            ($idx:tt, $ty:ty) => {
                 Field {
-                    name: "0",
-                    shape: ShapeDesc(T1::shape),
+                    name: stringify!($idx),
+                    shape: ShapeDesc(<$ty>::shape),
                     offset: std::mem::offset_of!(
-                        (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11,),
-                        0
+                        (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11),
+                        $idx
                     ),
                     flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "1",
-                    shape: ShapeDesc(T2::shape),
-                    offset: std::mem::offset_of!(
-                        (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11,),
-                        1
-                    ),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "2",
-                    shape: ShapeDesc(T3::shape),
-                    offset: std::mem::offset_of!(
-                        (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11,),
-                        2
-                    ),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "3",
-                    shape: ShapeDesc(T4::shape),
-                    offset: std::mem::offset_of!(
-                        (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11,),
-                        3
-                    ),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "4",
-                    shape: ShapeDesc(T5::shape),
-                    offset: std::mem::offset_of!(
-                        (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11,),
-                        4
-                    ),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "5",
-                    shape: ShapeDesc(T6::shape),
-                    offset: std::mem::offset_of!(
-                        (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11,),
-                        5
-                    ),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "6",
-                    shape: ShapeDesc(T7::shape),
-                    offset: std::mem::offset_of!(
-                        (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11,),
-                        6
-                    ),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "7",
-                    shape: ShapeDesc(T8::shape),
-                    offset: std::mem::offset_of!(
-                        (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11,),
-                        7
-                    ),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "8",
-                    shape: ShapeDesc(T9::shape),
-                    offset: std::mem::offset_of!(
-                        (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11,),
-                        8
-                    ),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "9",
-                    shape: ShapeDesc(T10::shape),
-                    offset: std::mem::offset_of!(
-                        (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11,),
-                        9
-                    ),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "10",
-                    shape: ShapeDesc(T11::shape),
-                    offset: std::mem::offset_of!(
-                        (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11,),
-                        10
-                    ),
-                    flags: FieldFlags::EMPTY,
-                },
-            ];
+                }
+            };
         }
 
         Shape {
             name: |f| {
                 write!(f, "(")?;
+                (T0::shape().name)(f)?;
+                write!(f, ",")?;
                 (T1::shape().name)(f)?;
                 write!(f, ",")?;
                 (T2::shape().name)(f)?;
@@ -1046,207 +693,29 @@ where
                 write!(f, ",)")
             },
             typeid: mini_typeid::of::<Self>(),
-            layout: Layout::new::<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)>(),
+            layout: Layout::new::<(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)>(),
             innards: Innards::Tuple {
-                fields: &FieldsMaker::<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>::FIELDS,
+                fields: &const {
+                    [
+                        field!(0, T0),
+                        field!(1, T1),
+                        field!(2, T2),
+                        field!(3, T3),
+                        field!(4, T4),
+                        field!(5, T5),
+                        field!(6, T6),
+                        field!(7, T7),
+                        field!(8, T8),
+                        field!(9, T9),
+                        field!(10, T10),
+                        field!(11, T11),
+                    ]
+                },
             },
             set_to_default: None,
             drop_in_place: Some(|addr: *mut u8| unsafe {
                 std::ptr::drop_in_place(
-                    addr as *mut (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11),
-                );
-            }),
-        }
-    }
-}
-
-impl<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Shapely
-    for (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-where
-    T1: Shapely,
-    T2: Shapely,
-    T3: Shapely,
-    T4: Shapely,
-    T5: Shapely,
-    T6: Shapely,
-    T7: Shapely,
-    T8: Shapely,
-    T9: Shapely,
-    T10: Shapely,
-    T11: Shapely,
-    T12: Shapely,
-{
-    fn shape() -> Shape {
-        struct FieldsMaker<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> {
-            #[allow(clippy::type_complexity)]
-            _phantom: std::marker::PhantomData<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)>,
-        }
-
-        impl<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>
-            FieldsMaker<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>
-        where
-            T1: Shapely,
-            T2: Shapely,
-            T3: Shapely,
-            T4: Shapely,
-            T5: Shapely,
-            T6: Shapely,
-            T7: Shapely,
-            T8: Shapely,
-            T9: Shapely,
-            T10: Shapely,
-            T11: Shapely,
-            T12: Shapely,
-        {
-            const FIELDS: [Field; 12] = [
-                Field {
-                    name: "0",
-                    shape: ShapeDesc(T1::shape),
-                    offset: std::mem::offset_of!(
-                        (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12,),
-                        0
-                    ),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "1",
-                    shape: ShapeDesc(T2::shape),
-                    offset: std::mem::offset_of!(
-                        (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12,),
-                        1
-                    ),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "2",
-                    shape: ShapeDesc(T3::shape),
-                    offset: std::mem::offset_of!(
-                        (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12,),
-                        2
-                    ),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "3",
-                    shape: ShapeDesc(T4::shape),
-                    offset: std::mem::offset_of!(
-                        (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12,),
-                        3
-                    ),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "4",
-                    shape: ShapeDesc(T5::shape),
-                    offset: std::mem::offset_of!(
-                        (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12,),
-                        4
-                    ),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "5",
-                    shape: ShapeDesc(T6::shape),
-                    offset: std::mem::offset_of!(
-                        (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12,),
-                        5
-                    ),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "6",
-                    shape: ShapeDesc(T7::shape),
-                    offset: std::mem::offset_of!(
-                        (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12,),
-                        6
-                    ),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "7",
-                    shape: ShapeDesc(T8::shape),
-                    offset: std::mem::offset_of!(
-                        (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12,),
-                        7
-                    ),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "8",
-                    shape: ShapeDesc(T9::shape),
-                    offset: std::mem::offset_of!(
-                        (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12,),
-                        8
-                    ),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "9",
-                    shape: ShapeDesc(T10::shape),
-                    offset: std::mem::offset_of!(
-                        (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12,),
-                        9
-                    ),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "10",
-                    shape: ShapeDesc(T11::shape),
-                    offset: std::mem::offset_of!(
-                        (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12,),
-                        10
-                    ),
-                    flags: FieldFlags::EMPTY,
-                },
-                Field {
-                    name: "11",
-                    shape: ShapeDesc(T12::shape),
-                    offset: std::mem::offset_of!(
-                        (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12,),
-                        11
-                    ),
-                    flags: FieldFlags::EMPTY,
-                },
-            ];
-        }
-
-        Shape {
-            name: |f| {
-                write!(f, "(")?;
-                (T1::shape().name)(f)?;
-                write!(f, ",")?;
-                (T2::shape().name)(f)?;
-                write!(f, ",")?;
-                (T3::shape().name)(f)?;
-                write!(f, ",")?;
-                (T4::shape().name)(f)?;
-                write!(f, ",")?;
-                (T5::shape().name)(f)?;
-                write!(f, ",")?;
-                (T6::shape().name)(f)?;
-                write!(f, ",")?;
-                (T7::shape().name)(f)?;
-                write!(f, ",")?;
-                (T8::shape().name)(f)?;
-                write!(f, ",")?;
-                (T9::shape().name)(f)?;
-                write!(f, ",")?;
-                (T10::shape().name)(f)?;
-                write!(f, ",")?;
-                (T11::shape().name)(f)?;
-                write!(f, ",")?;
-                (T12::shape().name)(f)?;
-                write!(f, ",)")
-            },
-            typeid: mini_typeid::of::<Self>(),
-            layout: Layout::new::<(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)>(),
-            innards: Innards::Tuple {
-                fields: &FieldsMaker::<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>::FIELDS,
-            },
-            set_to_default: None,
-            drop_in_place: Some(|addr: *mut u8| unsafe {
-                std::ptr::drop_in_place(
-                    addr as *mut (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12),
+                    addr as *mut (T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11),
                 );
             }),
         }


### PR DESCRIPTION
Const contexts _do_ have access to outer generics :)

https://bsky.app/profile/lukaswirth.bsky.social/post/3lloofn4tfk2d