### PR TITLE
Unfuck docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,6 @@
 [![documentation](https://docs.rs/shapely/badge.svg)](https://docs.rs/shapely)
 [![MIT/Apache-2.0 licensed](https://img.shields.io/crates/l/shapely.svg)](./LICENSE)
 
-> [!IMPORTANT]
->
-> There is no stable shapely API as of now (even though it's >1.0.0). The design
-> is very much still being explored.
->
-> Expect multiple major versions in the near future — (note left 2025-03-11)
-
 A Rust reflection, introspection, serialization and deserialization framework with support for multiple formats including JSON, YAML, MessagePack, URL-encoded data, and more.
 
 A single, lightweight derive macro (thanks to [unsynn](https://crates.io/crates/unsynn))

--- a/shapely-core/README.md
+++ b/shapely-core/README.md
@@ -6,13 +6,6 @@
 [![documentation](https://docs.rs/shapely-core/badge.svg)](https://docs.rs/shapely-core)
 [![MIT/Apache-2.0 licensed](https://img.shields.io/crates/l/shapely-core.svg)](./LICENSE)
 
-> [!IMPORTANT]
->
-> There is no stable shapely API as of now (even though it's >1.0.0). The design
-> is very much still being explored.
->
-> Expect multiple major versions in the near future — (note left 2025-03-11)
-
 This is the core crate for the shapely ecosystem. It provides the fundamental
 types and traits used by other crates in the shapely family.
 

--- a/shapely-core/src/impls.rs
+++ b/shapely-core/src/impls.rs
@@ -1,0 +1,4 @@
+mod hashmap_impl;
+mod scalar_impls;
+mod tuples_impls;
+mod vec_impl;

--- a/shapely-core/src/impls/scalar_impls.rs
+++ b/shapely-core/src/impls/scalar_impls.rs
@@ -7,7 +7,7 @@ macro_rules! impl_shapely_for_integer {
         impl Shapely for $type {
             fn shape() -> Shape {
                 Shape {
-                    name: |f| write!(f, stringify!($type)),
+                    name: |f, _nameopts| write!(f, stringify!($type)),
                     typeid: mini_typeid::of::<Self>(),
                     layout: Layout::new::<$type>(),
                     innards: Innards::Scalar($scalar),
@@ -38,7 +38,7 @@ macro_rules! impl_shapely_for_float {
         impl Shapely for $type {
             fn shape() -> Shape {
                 Shape {
-                    name: |f| write!(f, stringify!($type)),
+                    name: |f, _nameopts| write!(f, stringify!($type)),
                     typeid: mini_typeid::of::<Self>(),
                     layout: Layout::new::<$type>(),
                     innards: Innards::Scalar($scalar),
@@ -59,7 +59,7 @@ impl_shapely_for_float!(f64, Scalar::F64);
 impl Shapely for String {
     fn shape() -> Shape {
         Shape {
-            name: |f| write!(f, "String"),
+            name: |f, _nameopts| write!(f, "String"),
             typeid: mini_typeid::of::<Self>(),
             layout: Layout::new::<String>(),
             innards: Innards::Scalar(Scalar::String),
@@ -76,7 +76,7 @@ impl Shapely for String {
 impl Shapely for bool {
     fn shape() -> Shape {
         Shape {
-            name: |f| write!(f, "bool"),
+            name: |f, _nameopts| write!(f, "bool"),
             typeid: mini_typeid::of::<Self>(),
             layout: Layout::new::<bool>(),
             innards: Innards::Scalar(Scalar::Boolean),
@@ -92,7 +92,7 @@ impl Shapely for bool {
 impl Shapely for () {
     fn shape() -> Shape {
         Shape {
-            name: |f| write!(f, "()"),
+            name: |f, _nameopts| write!(f, "()"),
             typeid: mini_typeid::of::<Self>(),
             layout: Layout::new::<()>(),
             innards: Innards::Scalar(Scalar::Nothing),

--- a/shapely-core/src/impls/tuples_impls.rs
+++ b/shapely-core/src/impls/tuples_impls.rs
@@ -19,10 +19,14 @@ where
         }
 
         Shape {
-            name: |f| {
-                write!(f, "(")?;
-                (T0::shape().name)(f)?;
-                write!(f, ",)")
+            name: |f, opts| {
+                if let Some(opts) = opts.for_children() {
+                    write!(f, "(")?;
+                    (T0::shape().name)(f, opts)?;
+                    write!(f, ")")
+                } else {
+                    write!(f, "()")
+                }
             },
             typeid: mini_typeid::of::<Self>(),
             layout: Layout::new::<(T0,)>(),
@@ -55,12 +59,16 @@ where
         }
 
         Shape {
-            name: |f| {
-                write!(f, "(")?;
-                (T0::shape().name)(f)?;
-                write!(f, ",")?;
-                (T1::shape().name)(f)?;
-                write!(f, ",)")
+            name: |f, opts| {
+                if let Some(opts) = opts.for_children() {
+                    write!(f, "(")?;
+                    (T0::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T1::shape().name)(f, opts)?;
+                    write!(f, ")")
+                } else {
+                    write!(f, "()")
+                }
             },
             typeid: mini_typeid::of::<Self>(),
             layout: Layout::new::<(T0, T1)>(),
@@ -94,14 +102,18 @@ where
         }
 
         Shape {
-            name: |f| {
-                write!(f, "(")?;
-                (T0::shape().name)(f)?;
-                write!(f, ",")?;
-                (T1::shape().name)(f)?;
-                write!(f, ",")?;
-                (T2::shape().name)(f)?;
-                write!(f, ",)")
+            name: |f, opts| {
+                if let Some(opts) = opts.for_children() {
+                    write!(f, "(")?;
+                    (T0::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T1::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T2::shape().name)(f, opts)?;
+                    write!(f, ")")
+                } else {
+                    write!(f, "()")
+                }
             },
             typeid: mini_typeid::of::<Self>(),
             layout: Layout::new::<(T0, T1, T2)>(),
@@ -136,16 +148,20 @@ where
         }
 
         Shape {
-            name: |f| {
-                write!(f, "(")?;
-                (T0::shape().name)(f)?;
-                write!(f, ",")?;
-                (T1::shape().name)(f)?;
-                write!(f, ",")?;
-                (T2::shape().name)(f)?;
-                write!(f, ",")?;
-                (T3::shape().name)(f)?;
-                write!(f, ",)")
+            name: |f, opts| {
+                if let Some(opts) = opts.for_children() {
+                    write!(f, "(")?;
+                    (T0::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T1::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T2::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T3::shape().name)(f, opts)?;
+                    write!(f, ")")
+                } else {
+                    write!(f, "()")
+                }
             },
             typeid: mini_typeid::of::<Self>(),
             layout: Layout::new::<(T0, T1, T2, T3)>(),
@@ -181,18 +197,22 @@ where
         }
 
         Shape {
-            name: |f| {
-                write!(f, "(")?;
-                (T0::shape().name)(f)?;
-                write!(f, ",")?;
-                (T1::shape().name)(f)?;
-                write!(f, ",")?;
-                (T2::shape().name)(f)?;
-                write!(f, ",")?;
-                (T3::shape().name)(f)?;
-                write!(f, ",")?;
-                (T4::shape().name)(f)?;
-                write!(f, ",)")
+            name: |f, opts| {
+                if let Some(opts) = opts.for_children() {
+                    write!(f, "(")?;
+                    (T0::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T1::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T2::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T3::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T4::shape().name)(f, opts)?;
+                    write!(f, ")")
+                } else {
+                    write!(f, "()")
+                }
             },
             typeid: mini_typeid::of::<Self>(),
             layout: Layout::new::<(T0, T1, T2, T3, T4)>(),
@@ -237,20 +257,24 @@ where
         }
 
         Shape {
-            name: |f| {
-                write!(f, "(")?;
-                (T0::shape().name)(f)?;
-                write!(f, ",")?;
-                (T1::shape().name)(f)?;
-                write!(f, ",")?;
-                (T2::shape().name)(f)?;
-                write!(f, ",")?;
-                (T3::shape().name)(f)?;
-                write!(f, ",")?;
-                (T4::shape().name)(f)?;
-                write!(f, ",")?;
-                (T5::shape().name)(f)?;
-                write!(f, ",)")
+            name: |f, opts| {
+                if let Some(opts) = opts.for_children() {
+                    write!(f, "(")?;
+                    (T0::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T1::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T2::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T3::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T4::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T5::shape().name)(f, opts)?;
+                    write!(f, ")")
+                } else {
+                    write!(f, "()")
+                }
             },
             typeid: mini_typeid::of::<Self>(),
             layout: Layout::new::<(T0, T1, T2, T3, T4, T5)>(),
@@ -297,22 +321,26 @@ where
         }
 
         Shape {
-            name: |f| {
-                write!(f, "(")?;
-                (T0::shape().name)(f)?;
-                write!(f, ",")?;
-                (T1::shape().name)(f)?;
-                write!(f, ",")?;
-                (T2::shape().name)(f)?;
-                write!(f, ",")?;
-                (T3::shape().name)(f)?;
-                write!(f, ",")?;
-                (T4::shape().name)(f)?;
-                write!(f, ",")?;
-                (T5::shape().name)(f)?;
-                write!(f, ",")?;
-                (T6::shape().name)(f)?;
-                write!(f, ",)")
+            name: |f, opts| {
+                if let Some(opts) = opts.for_children() {
+                    write!(f, "(")?;
+                    (T0::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T1::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T2::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T3::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T4::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T5::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T6::shape().name)(f, opts)?;
+                    write!(f, ")")
+                } else {
+                    write!(f, "()")
+                }
             },
             typeid: mini_typeid::of::<Self>(),
             layout: Layout::new::<(T0, T1, T2, T3, T4, T5, T6)>(),
@@ -361,24 +389,28 @@ where
         }
 
         Shape {
-            name: |f| {
-                write!(f, "(")?;
-                (T0::shape().name)(f)?;
-                write!(f, ",")?;
-                (T1::shape().name)(f)?;
-                write!(f, ",")?;
-                (T2::shape().name)(f)?;
-                write!(f, ",")?;
-                (T3::shape().name)(f)?;
-                write!(f, ",")?;
-                (T4::shape().name)(f)?;
-                write!(f, ",")?;
-                (T5::shape().name)(f)?;
-                write!(f, ",")?;
-                (T6::shape().name)(f)?;
-                write!(f, ",")?;
-                (T7::shape().name)(f)?;
-                write!(f, ",)")
+            name: |f, opts| {
+                if let Some(opts) = opts.for_children() {
+                    write!(f, "(")?;
+                    (T0::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T1::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T2::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T3::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T4::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T5::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T6::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T7::shape().name)(f, opts)?;
+                    write!(f, ")")
+                } else {
+                    write!(f, "()")
+                }
             },
             typeid: mini_typeid::of::<Self>(),
             layout: Layout::new::<(T0, T1, T2, T3, T4, T5, T6, T7)>(),
@@ -429,26 +461,30 @@ where
         }
 
         Shape {
-            name: |f| {
-                write!(f, "(")?;
-                (T0::shape().name)(f)?;
-                write!(f, ",")?;
-                (T1::shape().name)(f)?;
-                write!(f, ",")?;
-                (T2::shape().name)(f)?;
-                write!(f, ",")?;
-                (T3::shape().name)(f)?;
-                write!(f, ",")?;
-                (T4::shape().name)(f)?;
-                write!(f, ",")?;
-                (T5::shape().name)(f)?;
-                write!(f, ",")?;
-                (T6::shape().name)(f)?;
-                write!(f, ",")?;
-                (T7::shape().name)(f)?;
-                write!(f, ",")?;
-                (T8::shape().name)(f)?;
-                write!(f, ",)")
+            name: |f, opts| {
+                if let Some(opts) = opts.for_children() {
+                    write!(f, "(")?;
+                    (T0::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T1::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T2::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T3::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T4::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T5::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T6::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T7::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T8::shape().name)(f, opts)?;
+                    write!(f, ")")
+                } else {
+                    write!(f, "()")
+                }
             },
             typeid: mini_typeid::of::<Self>(),
             layout: Layout::new::<(T0, T1, T2, T3, T4, T5, T6, T7, T8)>(),
@@ -501,28 +537,32 @@ where
         }
 
         Shape {
-            name: |f| {
-                write!(f, "(")?;
-                (T0::shape().name)(f)?;
-                write!(f, ",")?;
-                (T1::shape().name)(f)?;
-                write!(f, ",")?;
-                (T2::shape().name)(f)?;
-                write!(f, ",")?;
-                (T3::shape().name)(f)?;
-                write!(f, ",")?;
-                (T4::shape().name)(f)?;
-                write!(f, ",")?;
-                (T5::shape().name)(f)?;
-                write!(f, ",")?;
-                (T6::shape().name)(f)?;
-                write!(f, ",")?;
-                (T7::shape().name)(f)?;
-                write!(f, ",")?;
-                (T8::shape().name)(f)?;
-                write!(f, ",")?;
-                (T9::shape().name)(f)?;
-                write!(f, ",)")
+            name: |f, opts| {
+                if let Some(opts) = opts.for_children() {
+                    write!(f, "(")?;
+                    (T0::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T1::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T2::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T3::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T4::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T5::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T6::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T7::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T8::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T9::shape().name)(f, opts)?;
+                    write!(f, ")")
+                } else {
+                    write!(f, "()")
+                }
             },
             typeid: mini_typeid::of::<Self>(),
             layout: Layout::new::<(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9)>(),
@@ -581,30 +621,34 @@ where
         }
 
         Shape {
-            name: |f| {
-                write!(f, "(")?;
-                (T0::shape().name)(f)?;
-                write!(f, ",")?;
-                (T1::shape().name)(f)?;
-                write!(f, ",")?;
-                (T2::shape().name)(f)?;
-                write!(f, ",")?;
-                (T3::shape().name)(f)?;
-                write!(f, ",")?;
-                (T4::shape().name)(f)?;
-                write!(f, ",")?;
-                (T5::shape().name)(f)?;
-                write!(f, ",")?;
-                (T6::shape().name)(f)?;
-                write!(f, ",")?;
-                (T7::shape().name)(f)?;
-                write!(f, ",")?;
-                (T8::shape().name)(f)?;
-                write!(f, ",")?;
-                (T9::shape().name)(f)?;
-                write!(f, ",")?;
-                (T10::shape().name)(f)?;
-                write!(f, ",)")
+            name: |f, opts| {
+                if let Some(opts) = opts.for_children() {
+                    write!(f, "(")?;
+                    (T0::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T1::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T2::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T3::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T4::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T5::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T6::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T7::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T8::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T9::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T10::shape().name)(f, opts)?;
+                    write!(f, ")")
+                } else {
+                    write!(f, "()")
+                }
             },
             typeid: mini_typeid::of::<Self>(),
             layout: Layout::new::<(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)>(),
@@ -665,32 +709,36 @@ where
         }
 
         Shape {
-            name: |f| {
-                write!(f, "(")?;
-                (T0::shape().name)(f)?;
-                write!(f, ",")?;
-                (T1::shape().name)(f)?;
-                write!(f, ",")?;
-                (T2::shape().name)(f)?;
-                write!(f, ",")?;
-                (T3::shape().name)(f)?;
-                write!(f, ",")?;
-                (T4::shape().name)(f)?;
-                write!(f, ",")?;
-                (T5::shape().name)(f)?;
-                write!(f, ",")?;
-                (T6::shape().name)(f)?;
-                write!(f, ",")?;
-                (T7::shape().name)(f)?;
-                write!(f, ",")?;
-                (T8::shape().name)(f)?;
-                write!(f, ",")?;
-                (T9::shape().name)(f)?;
-                write!(f, ",")?;
-                (T10::shape().name)(f)?;
-                write!(f, ",")?;
-                (T11::shape().name)(f)?;
-                write!(f, ",)")
+            name: |f, opts| {
+                if let Some(opts) = opts.for_children() {
+                    write!(f, "(")?;
+                    (T0::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T1::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T2::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T3::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T4::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T5::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T6::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T7::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T8::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T9::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T10::shape().name)(f, opts)?;
+                    write!(f, ",")?;
+                    (T11::shape().name)(f, opts)?;
+                    write!(f, ")")
+                } else {
+                    write!(f, "()")
+                }
             },
             typeid: mini_typeid::of::<Self>(),
             layout: Layout::new::<(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)>(),

--- a/shapely-core/src/lib.rs
+++ b/shapely-core/src/lib.rs
@@ -1,9 +1,6 @@
 use std::mem::MaybeUninit;
 
-mod hashmap_impl;
-mod scalar_impls;
-mod tuples_impls;
-mod vec_impl;
+mod impls;
 
 mod scalar_contents;
 pub use scalar_contents::ScalarContents;

--- a/shapely-core/src/lib.rs
+++ b/shapely-core/src/lib.rs
@@ -36,7 +36,7 @@ pub struct Bytes(pub Vec<u8>);
 impl Shapely for Bytes {
     fn shape() -> Shape {
         Shape {
-            name: |f| write!(f, "Bytes"),
+            name: |f, _opts| write!(f, "Bytes"),
             typeid: mini_typeid::of::<Self>(),
             layout: std::alloc::Layout::new::<Self>(),
             innards: Innards::Scalar(Scalar::Bytes),

--- a/shapely-core/src/lib.rs
+++ b/shapely-core/src/lib.rs
@@ -32,7 +32,7 @@ mod tests;
 #[cfg(test)]
 mod scalar_contents_tests;
 
-/// A wrapper around Vec<u8> for binary data
+/// A wrapper around `Vec<u8>` for binary data
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Bytes(pub Vec<u8>);
 

--- a/shapely-core/src/partial.rs
+++ b/shapely-core/src/partial.rs
@@ -1,4 +1,4 @@
-use crate::{ArrayVtable, FieldError, Innards, ShapeDesc, Shapely, Slot, trace};
+use crate::{FieldError, Innards, ShapeDesc, Shapely, Slot, VecVTable, trace};
 use std::{alloc, ptr::NonNull};
 
 /// Origin of the partial — did we allocate it? Or is it borrowed?
@@ -208,7 +208,7 @@ impl Partial<'_> {
     /// Returns a slot for treating this partial as an array (onto which you can push new items)
     pub fn array_slot(&mut self, size_hint: Option<usize>) -> Option<ArraySlot> {
         match self.shape.get().innards {
-            crate::Innards::Array {
+            crate::Innards::Vec {
                 vtable,
                 item_shape: _,
             } => {
@@ -336,7 +336,7 @@ impl Partial<'_> {
             Innards::HashMap { .. } => Err(FieldError::NoStaticFields),
             Innards::Transparent(_) => Err(FieldError::NoStaticFields),
             Innards::Scalar(_) => Err(FieldError::NoStaticFields),
-            Innards::Array { .. } => Err(FieldError::NoStaticFields),
+            Innards::Vec { .. } => Err(FieldError::NoStaticFields),
             Innards::Enum {
                 variants: _,
                 repr: _,
@@ -1024,12 +1024,12 @@ impl InitMark<'_> {
 /// rather than fixed-size arrays or slices, so it's a bit of a misnomer at the moment.
 pub struct ArraySlot {
     pub(crate) addr: NonNull<u8>,
-    pub(crate) vtable: ArrayVtable,
+    pub(crate) vtable: VecVTable,
 }
 
 impl ArraySlot {
     /// Create a new ArraySlot with the given address and vtable
-    pub(crate) unsafe fn new(addr: NonNull<u8>, vtable: ArrayVtable) -> Self {
+    pub(crate) unsafe fn new(addr: NonNull<u8>, vtable: VecVTable) -> Self {
         Self { addr, vtable }
     }
 
@@ -1051,12 +1051,12 @@ impl ArraySlot {
 /// Provides insert, length check, and iteration over a type-erased hashmap
 pub struct HashMapSlot {
     pub(crate) addr: NonNull<u8>,
-    pub(crate) vtable: crate::HashMapVtable,
+    pub(crate) vtable: crate::HashMapVTable,
 }
 
 impl HashMapSlot {
     /// Create a new HashMapSlot with the given address and vtable
-    pub(crate) unsafe fn new(addr: NonNull<u8>, vtable: crate::HashMapVtable) -> Self {
+    pub(crate) unsafe fn new(addr: NonNull<u8>, vtable: crate::HashMapVTable) -> Self {
         Self { addr, vtable }
     }
 

--- a/shapely-core/src/shape/enum_shape.rs
+++ b/shapely-core/src/shape/enum_shape.rs
@@ -1,0 +1,82 @@
+use super::Field;
+
+/// Describes a variant of an enum
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Variant {
+    /// Name of the variant
+    pub name: &'static str,
+
+    /// Discriminant value (if available)
+    pub discriminant: Option<i64>,
+
+    /// Kind of variant (unit, tuple, or struct)
+    pub kind: VariantKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum VariantKind {
+    /// Unit variant (e.g., `None` in Option)
+    Unit,
+
+    /// Tuple variant with unnamed fields (e.g., `Some(T)` in Option)
+    Tuple { fields: &'static [Field] },
+
+    /// Struct variant with named fields (e.g., `Struct { field: T }`)
+    Struct { fields: &'static [Field] },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum EnumRepr {
+    /// Default representation (compiler-dependent)
+    Default,
+    /// u8 representation (#[repr(u8)])
+    U8,
+    /// u16 representation (#[repr(u16)])
+    U16,
+    /// u32 representation (#[repr(u32)])
+    U32,
+    /// u64 representation (#[repr(u64)])
+    U64,
+    /// usize representation (#[repr(usize)])
+    USize,
+    /// i8 representation (#[repr(i8)])
+    I8,
+    /// i16 representation (#[repr(i16)])
+    I16,
+    /// i32 representation (#[repr(i32)])
+    I32,
+    /// i64 representation (#[repr(i64)])
+    I64,
+    /// isize representation (#[repr(isize)])
+    ISize,
+}
+
+impl Default for EnumRepr {
+    fn default() -> Self {
+        Self::Default
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum VariantError {
+    /// `variant_by_index` was called with an index that is out of bounds.
+    IndexOutOfBounds,
+
+    /// `variant_by_name` or `variant_by_index` was called on a non-enum type.
+    NotAnEnum,
+
+    /// `variant_by_name` was called with a name that doesn't match any variant.
+    NoSuchVariant,
+}
+
+impl std::error::Error for VariantError {}
+
+impl std::fmt::Display for VariantError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VariantError::IndexOutOfBounds => write!(f, "Variant index out of bounds"),
+            VariantError::NotAnEnum => write!(f, "Not an enum"),
+            VariantError::NoSuchVariant => write!(f, "No such variant"),
+        }
+    }
+}

--- a/shapely-core/src/shape/hashmap_shape.rs
+++ b/shapely-core/src/shape/hashmap_shape.rs
@@ -1,0 +1,31 @@
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub struct HashMapVTable {
+    // Initialize an empty HashMap at the given pointer
+    pub init: unsafe fn(ptr: *mut u8, size_hint: Option<usize>),
+
+    // Insert a key-value pair into the HashMap
+    pub insert: unsafe fn(*mut u8, key: crate::Partial, value: crate::Partial),
+
+    // Get the number of entries in the HashMap
+    pub len: unsafe fn(ptr: *const u8) -> usize,
+
+    // Check if the HashMap contains a key
+    pub contains_key: unsafe fn(ptr: *const u8, key: &str) -> bool,
+
+    // Get pointer to a value for a given key, returns null if not found
+    pub get_value_ptr: unsafe fn(ptr: *const u8, key: &str) -> *const u8,
+
+    // Get an iterator over the hashmap
+    pub iter: unsafe fn(ptr: *const u8) -> *const u8,
+
+    pub iter_vtable: HashMapIterVtable,
+}
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub struct HashMapIterVtable {
+    // Get the next key-value pair from the iterator
+    pub next: unsafe fn(*const u8) -> Option<(*const String, *const u8)>,
+
+    // Deallocate the iterator
+    pub dealloc: unsafe fn(*const u8),
+}

--- a/shapely-core/src/shape/pretty_print.rs
+++ b/shapely-core/src/shape/pretty_print.rs
@@ -1,4 +1,4 @@
-use super::{Innards, NameOpts, Shape, VariantKind};
+use super::{FieldFlags, Innards, NameOpts, Shape, VariantKind};
 use std::{collections::HashSet, fmt::Formatter};
 
 impl Shape {

--- a/shapely-core/src/shape/pretty_print.rs
+++ b/shapely-core/src/shape/pretty_print.rs
@@ -1,4 +1,4 @@
-use super::{Innards, Shape, VariantKind};
+use super::{Innards, NameOpts, Shape, VariantKind};
 use std::{collections::HashSet, fmt::Formatter};
 
 impl Shape {
@@ -15,13 +15,13 @@ impl Shape {
     ) -> std::fmt::Result {
         if !printed_schemas.insert(*self) {
             write!(f, "{:indent$}\x1b[1;33m", "", indent = indent)?;
-            (self.name)(f)?;
+            (self.name)(f, NameOpts::one())?;
             writeln!(f, "\x1b[0m (\x1b[1;31malready printed\x1b[0m)")?;
             return Ok(());
         }
 
         write!(f, "{:indent$}\x1b[1;33m", "", indent = indent)?;
-        (self.name)(f)?;
+        (self.name)(f, NameOpts::default())?;
         writeln!(f, "\x1b[0m (\x1b[1;34m{}\x1b[0m bytes)", self.layout.size())?;
 
         match &self.innards {
@@ -39,7 +39,7 @@ impl Shape {
                         indent = indent + Self::INDENT,
                         width = max_name_length
                     )?;
-                    if field.flags.is_sensitive() {
+                    if field.flags.contains(FieldFlags::SENSITIVE) {
                         write!(f, "(sensitive) ")?;
                     }
                     if let Innards::Scalar(_) = field.shape.get().innards {
@@ -71,7 +71,7 @@ impl Shape {
                     indent + Self::INDENT * 2,
                 )?;
             }
-            Innards::Array { item_shape, .. } => {
+            Innards::Vec { item_shape, .. } => {
                 write!(
                     f,
                     "{:indent$}\x1b[1;36mArray of:\x1b[0m ",
@@ -149,7 +149,7 @@ impl Shape {
                                     field.name,
                                     indent = indent + Self::INDENT * 3
                                 )?;
-                                if field.flags.is_sensitive() {
+                                if field.flags.contains(FieldFlags::SENSITIVE) {
                                     write!(f, "(sensitive) ")?;
                                 }
                                 if let Innards::Scalar(_) = field.shape.get().innards {
@@ -188,7 +188,7 @@ impl Shape {
                                     field.name,
                                     indent = indent + Self::INDENT * 3
                                 )?;
-                                if field.flags.is_sensitive() {
+                                if field.flags.contains(FieldFlags::SENSITIVE) {
                                     write!(f, "(sensitive) ")?;
                                 }
                                 if let Innards::Scalar(_) = field.shape.get().innards {

--- a/shapely-core/src/shape/scalar_shape.rs
+++ b/shapely-core/src/shape/scalar_shape.rs
@@ -1,0 +1,29 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum Scalar {
+    // Valid utf-8
+    String,
+
+    // Not valid utf-8 🤷
+    Bytes,
+
+    I8,
+    I16,
+    I32,
+    I64,
+    I128,
+
+    U8,
+    U16,
+    U32,
+    U64,
+    U128,
+
+    F32,
+    F64,
+
+    Boolean,
+
+    /// An empty tuple, null, undefined, whatever you wish
+    Nothing,
+}

--- a/shapely-core/src/shape/struct_shape.rs
+++ b/shapely-core/src/shape/struct_shape.rs
@@ -25,7 +25,7 @@ pub struct Field {
 ///
 /// // Create flags with the sensitive bit set
 /// let flags = FieldFlags::SENSITIVE;
-/// assert!(flags.has_flag(FieldFlags::SENSITIVE));
+/// assert!(flags.contains(FieldFlags::SENSITIVE));
 ///
 /// // Combine multiple flags using bitwise OR
 /// let flags = FieldFlags::SENSITIVE | FieldFlags::EMPTY;

--- a/shapely-core/src/shape/struct_shape.rs
+++ b/shapely-core/src/shape/struct_shape.rs
@@ -42,7 +42,7 @@ impl FieldFlags {
 
     /// Returns true if the given flag is set
     #[inline]
-    pub fn has_flag(&self, flag: FieldFlags) -> bool {
+    pub fn contains(&self, flag: FieldFlags) -> bool {
         self.0 & flag.0 != 0
     }
 

--- a/shapely-core/src/shape/struct_shape.rs
+++ b/shapely-core/src/shape/struct_shape.rs
@@ -1,0 +1,119 @@
+use super::ShapeDesc;
+
+/// Describes a field in a struct or tuple
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Field {
+    /// key for the struct field (for tuples and tuple-structs, this is the 0-based index)
+    pub name: &'static str,
+
+    /// schema of the inner type
+    pub shape: ShapeDesc,
+
+    /// offset of the field in the struct (obtained through `std::mem::offset_of`)
+    pub offset: usize,
+
+    /// flags for the field (e.g. sensitive, etc.)
+    pub flags: FieldFlags,
+}
+
+/// Flags that can be applied to fields to modify their behavior
+///
+/// # Examples
+///
+/// ```rust
+/// use shapely_core::FieldFlags;
+///
+/// // Create flags with the sensitive bit set
+/// let flags = FieldFlags::SENSITIVE;
+/// assert!(flags.has_flag(FieldFlags::SENSITIVE));
+///
+/// // Combine multiple flags using bitwise OR
+/// let flags = FieldFlags::SENSITIVE | FieldFlags::EMPTY;
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FieldFlags(u64);
+
+impl FieldFlags {
+    /// An empty set of flags
+    pub const EMPTY: Self = Self(0);
+
+    /// Flag indicating this field contains sensitive data that should not be displayed
+    pub const SENSITIVE: Self = Self(1 << 0);
+
+    /// Returns true if the given flag is set
+    #[inline]
+    pub fn has_flag(&self, flag: FieldFlags) -> bool {
+        self.0 & flag.0 != 0
+    }
+
+    /// Sets the given flag and returns self for chaining
+    #[inline]
+    pub fn set_flag(&mut self, flag: FieldFlags) -> &mut Self {
+        self.0 |= flag.0;
+        self
+    }
+
+    /// Unsets the given flag and returns self for chaining
+    #[inline]
+    pub fn unset_flag(&mut self, flag: FieldFlags) -> &mut Self {
+        self.0 &= !flag.0;
+        self
+    }
+
+    /// Creates a new FieldFlags with the given flag set
+    #[inline]
+    pub const fn with_flag(flag: FieldFlags) -> Self {
+        Self(flag.0)
+    }
+}
+
+impl std::ops::BitOr for FieldFlags {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self {
+        Self(self.0 | rhs.0)
+    }
+}
+
+impl std::ops::BitOrAssign for FieldFlags {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
+    }
+}
+
+impl Default for FieldFlags {
+    #[inline(always)]
+    fn default() -> Self {
+        Self::EMPTY
+    }
+}
+
+impl std::fmt::Display for FieldFlags {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.0 == 0 {
+            return write!(f, "none");
+        }
+
+        // Define a vector of flag entries: (flag bit, name)
+        let flags = [
+            (Self::SENSITIVE.0, "sensitive"),
+            // Future flags can be easily added here:
+            // (Self::SOME_FLAG.0, "some_flag"),
+            // (Self::ANOTHER_FLAG.0, "another_flag"),
+        ];
+
+        // Write all active flags with proper separators
+        let mut is_first = true;
+        for (bit, name) in flags {
+            if self.0 & bit != 0 {
+                if !is_first {
+                    write!(f, ", ")?;
+                }
+                is_first = false;
+                write!(f, "{}", name)?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/shapely-core/src/shape/vec_shape.rs
+++ b/shapely-core/src/shape/vec_shape.rs
@@ -1,0 +1,14 @@
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub struct VecVTable {
+    /// init given pointer to be an empty vec (with capacity)
+    pub init: unsafe fn(ptr: *mut u8, size_hint: Option<usize>),
+
+    /// push an item
+    pub push: unsafe fn(*mut u8, crate::Partial),
+
+    /// get length of the collection
+    pub len: unsafe fn(ptr: *const u8) -> usize,
+
+    /// get address of the item at the given index. panics if out of bound.
+    pub get_item_ptr: unsafe fn(ptr: *const u8, index: usize) -> *const u8,
+}

--- a/shapely-core/src/tests.rs
+++ b/shapely-core/src/tests.rs
@@ -11,7 +11,7 @@ struct FooBar {
 impl Shapely for FooBar {
     fn shape() -> crate::Shape {
         Shape {
-            name: |f| write!(f, "FooBar"),
+            name: |f, _nameopts| write!(f, "FooBar"),
             typeid: mini_typeid::of::<Self>(),
             layout: std::alloc::Layout::new::<Self>(),
             innards: crate::Innards::Struct {
@@ -126,7 +126,7 @@ fn build_struct_with_drop_field() {
     impl Shapely for DropCounter {
         fn shape() -> crate::Shape {
             Shape {
-                name: |f| write!(f, "DropCounter"),
+                name: |f, _nameopts| write!(f, "DropCounter"),
                 typeid: mini_typeid::of::<DropCounter>(),
                 layout: std::alloc::Layout::new::<DropCounter>(),
                 innards: crate::Innards::Struct { fields: &[] },
@@ -152,7 +152,7 @@ fn build_struct_with_drop_field() {
     impl Shapely for StructWithDrop {
         fn shape() -> crate::Shape {
             Shape {
-                name: |f| write!(f, "StructWithDrop"),
+                name: |f, _nameopts| write!(f, "StructWithDrop"),
                 typeid: mini_typeid::of::<Self>(),
                 layout: std::alloc::Layout::new::<Self>(),
                 innards: crate::Innards::Struct {
@@ -209,7 +209,7 @@ fn build_scalar_with_drop() {
     impl Shapely for DropScalar {
         fn shape() -> crate::Shape {
             Shape {
-                name: |f| write!(f, "DropScalar"),
+                name: |f, _nameopts| write!(f, "DropScalar"),
                 typeid: mini_typeid::of::<Self>(),
                 layout: std::alloc::Layout::new::<Self>(),
                 innards: crate::Innards::Scalar(crate::Scalar::Nothing),
@@ -276,7 +276,7 @@ fn build_truck_with_drop_fields() {
     impl Shapely for Engine {
         fn shape() -> crate::Shape {
             Shape {
-                name: |f| write!(f, "Engine"),
+                name: |f, _nameopts| write!(f, "Engine"),
                 typeid: mini_typeid::of::<Self>(),
                 layout: std::alloc::Layout::new::<Self>(),
                 innards: crate::Innards::Scalar(crate::Scalar::Nothing),
@@ -291,7 +291,7 @@ fn build_truck_with_drop_fields() {
     impl Shapely for Wheels {
         fn shape() -> crate::Shape {
             Shape {
-                name: |f| write!(f, "Wheels"),
+                name: |f, _nameopts| write!(f, "Wheels"),
                 typeid: mini_typeid::of::<Self>(),
                 layout: std::alloc::Layout::new::<Self>(),
                 innards: crate::Innards::Scalar(crate::Scalar::Nothing),
@@ -309,7 +309,7 @@ fn build_truck_with_drop_fields() {
     impl Shapely for Truck {
         fn shape() -> crate::Shape {
             Shape {
-                name: |f| write!(f, "Truck"),
+                name: |f, _nameopts| write!(f, "Truck"),
                 typeid: mini_typeid::of::<Self>(),
                 layout: std::alloc::Layout::new::<Self>(),
                 innards: crate::Innards::Struct {
@@ -414,7 +414,7 @@ fn test_partial_build_in_place() {
     impl Shapely for DropCounter {
         fn shape() -> crate::Shape {
             Shape {
-                name: |f| write!(f, "DropCounter"),
+                name: |f, _nameopts| write!(f, "DropCounter"),
                 typeid: mini_typeid::of::<Self>(),
                 layout: std::alloc::Layout::new::<Self>(),
                 innards: crate::Innards::Struct { fields: &[] },
@@ -438,7 +438,7 @@ fn test_partial_build_in_place() {
     impl Shapely for TestShape {
         fn shape() -> crate::Shape {
             Shape {
-                name: |f| write!(f, "TestShape"),
+                name: |f, _nameopts| write!(f, "TestShape"),
                 typeid: mini_typeid::of::<Self>(),
                 layout: std::alloc::Layout::new::<Self>(),
                 innards: crate::Innards::Struct {
@@ -477,7 +477,7 @@ fn test_partial_build_transparent() {
     impl Shapely for InnerType {
         fn shape() -> crate::Shape {
             Shape {
-                name: |f| write!(f, "InnerType"),
+                name: |f, _nameopts| write!(f, "InnerType"),
                 typeid: mini_typeid::of::<Self>(),
                 layout: std::alloc::Layout::new::<Self>(),
                 innards: crate::Innards::Scalar(crate::Scalar::U32),
@@ -493,7 +493,7 @@ fn test_partial_build_transparent() {
     impl Shapely for TransparentWrapper {
         fn shape() -> crate::Shape {
             Shape {
-                name: |f| write!(f, "TransparentWrapper"),
+                name: |f, _nameopts| write!(f, "TransparentWrapper"),
                 typeid: mini_typeid::of::<Self>(),
                 layout: std::alloc::Layout::new::<Self>(),
                 innards: crate::Innards::Transparent(InnerType::shape_desc()),
@@ -554,7 +554,7 @@ impl Shapely for UserStatus {
         }
 
         Shape {
-            name: |f| write!(f, "UserStatus"),
+            name: |f, _nameopts| write!(f, "UserStatus"),
             typeid: mini_typeid::of::<Self>(),
             layout: std::alloc::Layout::new::<Self>(),
             innards: crate::Innards::Enum {
@@ -669,7 +669,7 @@ impl Shapely for SimpleEnum {
         }
 
         Shape {
-            name: |f| write!(f, "SimpleEnum"),
+            name: |f, _nameopts| write!(f, "SimpleEnum"),
             typeid: mini_typeid::of::<Self>(),
             layout: std::alloc::Layout::new::<Self>(),
             innards: crate::Innards::Enum {
@@ -800,7 +800,7 @@ fn test_build_simple_enum_with_explicit_repr() {
             }
 
             Shape {
-                name: |f| write!(f, "ExplicitReprEnum"),
+                name: |f, _nameopts| write!(f, "ExplicitReprEnum"),
                 typeid: mini_typeid::of::<Self>(),
                 layout: std::alloc::Layout::new::<Self>(),
                 innards: crate::Innards::Enum {
@@ -903,7 +903,7 @@ fn test_build_enum_with_custom_discriminants() {
             }
 
             Shape {
-                name: |f| write!(f, "CustomDiscEnum"),
+                name: |f, _nameopts| write!(f, "CustomDiscEnum"),
                 typeid: mini_typeid::of::<Self>(),
                 layout: std::alloc::Layout::new::<Self>(),
                 innards: crate::Innards::Enum {
@@ -977,7 +977,7 @@ fn test_build_enum_with_simple_variant() {
             }
 
             Shape {
-                name: |f| write!(f, "SimpleVariantEnum"),
+                name: |f, _nameopts| write!(f, "SimpleVariantEnum"),
                 typeid: mini_typeid::of::<Self>(),
                 layout: std::alloc::Layout::new::<Self>(),
                 innards: crate::Innards::Enum {
@@ -1071,7 +1071,7 @@ fn test_build_enum_with_struct_variant() {
             }
 
             Shape {
-                name: |f| write!(f, "StructEnum"),
+                name: |f, _nameopts| write!(f, "StructEnum"),
                 typeid: mini_typeid::of::<Self>(),
                 layout: std::alloc::Layout::new::<Self>(),
                 innards: crate::Innards::Enum {
@@ -1178,7 +1178,7 @@ fn test_enum_without_repr() {
             }
 
             Shape {
-                name: |f| write!(f, "NoReprEnum"),
+                name: |f, _nameopts| write!(f, "NoReprEnum"),
                 typeid: mini_typeid::of::<Self>(),
                 layout: std::alloc::Layout::new::<Self>(),
                 innards: crate::Innards::Enum {
@@ -1268,7 +1268,7 @@ fn test_complex_nested_recursive_enums() {
             }
 
             Shape {
-                name: |f| write!(f, "NestedData"),
+                name: |f, _nameopts| write!(f, "NestedData"),
                 typeid: mini_typeid::of::<Self>(),
                 layout: std::alloc::Layout::new::<Self>(),
                 innards: crate::Innards::Enum {
@@ -1389,7 +1389,7 @@ fn test_complex_nested_recursive_enums() {
             }
 
             Shape {
-                name: |f| write!(f, "ComplexEnum"),
+                name: |f, _nameopts| write!(f, "ComplexEnum"),
                 typeid: mini_typeid::of::<Self>(),
                 layout: std::alloc::Layout::new::<Self>(),
                 innards: crate::Innards::Enum {
@@ -1406,7 +1406,7 @@ fn test_complex_nested_recursive_enums() {
     impl Shapely for Box<ComplexEnum> {
         fn shape() -> crate::Shape {
             Shape {
-                name: |f| write!(f, "Box<ComplexEnum>"),
+                name: |f, _nameopts| write!(f, "Box<ComplexEnum>"),
                 typeid: mini_typeid::of::<Self>(),
                 layout: std::alloc::Layout::new::<Self>(),
                 innards: crate::Innards::Transparent(crate::ShapeDesc(ComplexEnum::shape)),
@@ -1555,7 +1555,7 @@ fn test_nightmare_reflection() {
             }
 
             Shape {
-                name: |f| write!(f, "InnerData"),
+                name: |f, _nameopts| write!(f, "InnerData"),
                 typeid: mini_typeid::of::<Self>(),
                 layout: std::alloc::Layout::new::<Self>(),
                 innards: crate::Innards::Enum {
@@ -1638,7 +1638,7 @@ fn test_nightmare_reflection() {
             }
 
             Shape {
-                name: |f| write!(f, "OuterData"),
+                name: |f, _nameopts| write!(f, "OuterData"),
                 typeid: mini_typeid::of::<Self>(),
                 layout: std::alloc::Layout::new::<Self>(),
                 innards: crate::Innards::Enum {
@@ -1655,7 +1655,7 @@ fn test_nightmare_reflection() {
     impl Shapely for Box<InnerData> {
         fn shape() -> crate::Shape {
             Shape {
-                name: |f| write!(f, "Box<InnerData>"),
+                name: |f, _nameopts| write!(f, "Box<InnerData>"),
                 typeid: mini_typeid::of::<Self>(),
                 layout: std::alloc::Layout::new::<Self>(),
                 innards: crate::Innards::Transparent(crate::ShapeDesc(InnerData::shape)),
@@ -1760,7 +1760,7 @@ fn test_struct_with_enum_field() {
             }
 
             Shape {
-                name: |f| write!(f, "Status"),
+                name: |f, _nameopts| write!(f, "Status"),
                 typeid: mini_typeid::of::<Self>(),
                 layout: std::alloc::Layout::new::<Self>(),
                 innards: crate::Innards::Enum {
@@ -1776,7 +1776,7 @@ fn test_struct_with_enum_field() {
     impl Shapely for User {
         fn shape() -> crate::Shape {
             Shape {
-                name: |f| write!(f, "User"),
+                name: |f, _nameopts| write!(f, "User"),
                 typeid: mini_typeid::of::<Self>(),
                 layout: std::alloc::Layout::new::<Self>(),
                 innards: crate::Innards::Struct {

--- a/shapely-derive/README.md
+++ b/shapely-derive/README.md
@@ -6,13 +6,6 @@
 [![documentation](https://docs.rs/shapely-derive/badge.svg)](https://docs.rs/shapely-derive)
 [![MIT/Apache-2.0 licensed](https://img.shields.io/crates/l/shapely-derive.svg)](./LICENSE)
 
-> [!IMPORTANT]
->
-> There is no stable shapely API as of now (even though it's >1.0.0). The design
-> is very much still being explored.
->
-> Expect multiple major versions in the near future — (note left 2025-03-11)
-
 shapely-derive provides procedural macros to derive the `Shapely` trait from shapely.
 
 This crate implements the `#[derive(Shapely)]` macro which automatically generates runtime reflection code for Rust structs, providing:

--- a/shapely-derive/src/lib.rs
+++ b/shapely-derive/src/lib.rs
@@ -247,7 +247,7 @@ fn process_struct(parsed: Struct) -> proc_macro::TokenStream {
             impl shapely::Shapely for {struct_name} {{
                 fn shape() -> shapely::Shape {{
                     shapely::Shape {{
-                        name: |f| std::fmt::Write::write_str(f, "{struct_name}"),
+                        name: |f, _opts| std::fmt::Write::write_str(f, "{struct_name}"),
                         typeid: shapely::mini_typeid::of::<Self>(),
                         layout: std::alloc::Layout::new::<Self>(),
                         innards: shapely::Innards::Struct {{
@@ -291,7 +291,7 @@ fn process_tuple_struct(parsed: TupleStruct) -> proc_macro::TokenStream {
             impl shapely::Shapely for {struct_name} {{
                 fn shape() -> shapely::Shape {{
                     shapely::Shape {{
-                        name: |f| std::fmt::Write::write_str(f, "{struct_name}"),
+                        name: |f, _opts| std::fmt::Write::write_str(f, "{struct_name}"),
                         typeid: shapely::mini_typeid::of::<Self>(),
                         layout: std::alloc::Layout::new::<Self>(),
                         innards: shapely::Innards::TupleStruct {{
@@ -408,7 +408,7 @@ fn process_enum(parsed: Enum) -> proc_macro::TokenStream {
             impl shapely::Shapely for {enum_name} {{
                 fn shape() -> shapely::Shape {{
                     shapely::Shape {{
-                        name: |f| std::fmt::Write::write_str(f, "{enum_name}"),
+                        name: |f, _opts| std::fmt::Write::write_str(f, "{enum_name}"),
                         typeid: shapely::mini_typeid::of::<Self>(),
                         layout: std::alloc::Layout::new::<Self>(),
                         innards: shapely::Innards::Enum {{

--- a/shapely-json/README.md
+++ b/shapely-json/README.md
@@ -6,13 +6,6 @@
 [![documentation](https://docs.rs/shapely-json/badge.svg)](https://docs.rs/shapely-json)
 [![MIT/Apache-2.0 licensed](https://img.shields.io/crates/l/shapely-json.svg)](./LICENSE)
 
-> [!IMPORTANT]
->
-> There is no stable shapely API as of now (even though it's >1.0.0). The design
-> is very much still being explored.
->
-> Expect multiple major versions in the near future — (note left 2025-03-11)
-
 A serialization and deserialization library for JSON using the shapely runtime reflection system.
 
 ## Features
@@ -52,7 +45,7 @@ Thanks to Namespace for providing fast GitHub Actions workers:
 
 Licensed under either of:
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your option.

--- a/shapely-json/src/from_json.rs
+++ b/shapely-json/src/from_json.rs
@@ -133,7 +133,7 @@ pub fn from_json<'input>(
 
                 trace!("Finished deserializing \x1b[1;36mtuple struct\x1b[0m");
             }
-            Innards::Array { item_shape, .. } => {
+            Innards::Vec { item_shape, .. } => {
                 trace!("Deserializing \x1b[1;36marray\x1b[0m");
 
                 // Parse array start

--- a/shapely-json/src/lib.rs
+++ b/shapely-json/src/lib.rs
@@ -1,4 +1,5 @@
-#[doc = include_str!("../README.md")]
+#![doc = include_str!("../README.md")]
+
 mod parser;
 
 #[cfg(test)]

--- a/shapely-json/src/tests.rs
+++ b/shapely-json/src/tests.rs
@@ -30,7 +30,7 @@ fn test_to_json() {
     impl Shapely for TestStruct {
         fn shape() -> shapely::Shape {
             shapely::Shape {
-                name: |f| write!(f, "TestStruct"),
+                name: |f, _opts| write!(f, "TestStruct"),
                 layout: std::alloc::Layout::new::<Self>(),
                 innards: shapely::Innards::Struct {
                     fields: shapely::struct_fields!(TestStruct, (name, age)),

--- a/shapely-json/src/to_json.rs
+++ b/shapely-json/src/to_json.rs
@@ -113,7 +113,7 @@ pub fn to_json<W: Write>(
                 }
                 write!(writer, "}}")
             }
-            Innards::Array { vtable, item_shape } => {
+            Innards::Vec { vtable, item_shape } => {
                 write!(writer, "[")?;
                 if indent {
                     writeln!(writer)?;

--- a/shapely-msgpack/README.md
+++ b/shapely-msgpack/README.md
@@ -6,13 +6,6 @@
 [![documentation](https://docs.rs/shapely-msgpack/badge.svg)](https://docs.rs/shapely-msgpack)
 [![MIT/Apache-2.0 licensed](https://img.shields.io/crates/l/shapely-msgpack.svg)](./LICENSE)
 
-> [!IMPORTANT]
->
-> There is no stable shapely API as of now (even though it's >1.0.0). The design
-> is very much still being explored.
->
-> Expect multiple major versions in the near future — (note left 2025-03-11)
-
 A crate for deserializing [MessagePack](https://msgpack.org/) data into Shapely structures.
 
 ## Example
@@ -51,7 +44,7 @@ Thanks to Namespace for providing fast GitHub Actions workers:
 
 Licensed under either of:
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your option.

--- a/shapely-msgpack/src/constants.rs
+++ b/shapely-msgpack/src/constants.rs
@@ -1,46 +1,46 @@
 /// MessagePack type tags
-/// As defined in the MessagePack specification: https://github.com/msgpack/msgpack/blob/master/spec.md
+/// As defined in the MessagePack specification: <https://github.com/msgpack/msgpack/blob/master/spec.md>
 /// Nil format - Represents nil/null values
-/// Ref: https://github.com/msgpack/msgpack/blob/master/spec.md#formats-nil
+/// Ref: <https://github.com/msgpack/msgpack/blob/master/spec.md#formats-nil>
 pub const MSGPACK_NIL: u8 = 0xc0;
 
 /// Boolean format family - Represents true/false values
-/// Ref: https://github.com/msgpack/msgpack/blob/master/spec.md#formats-bool
+/// Ref: <https://github.com/msgpack/msgpack/blob/master/spec.md#formats-bool>
 pub const MSGPACK_FALSE: u8 = 0xc2;
 pub const MSGPACK_TRUE: u8 = 0xc3;
 
 /// Binary format family - Represents byte arrays
-/// Ref: https://github.com/msgpack/msgpack/blob/master/spec.md#formats-bin
+/// Ref: <https://github.com/msgpack/msgpack/blob/master/spec.md#formats-bin>
 pub const MSGPACK_BIN8: u8 = 0xc4;
 pub const MSGPACK_BIN16: u8 = 0xc5;
 pub const MSGPACK_BIN32: u8 = 0xc6;
 
 /// Extension format family - Represents custom type information with byte arrays
-/// Ref: https://github.com/msgpack/msgpack/blob/master/spec.md#formats-ext
+/// Ref: <https://github.com/msgpack/msgpack/blob/master/spec.md#formats-ext>
 pub const MSGPACK_EXT8: u8 = 0xc7;
 pub const MSGPACK_EXT16: u8 = 0xc8;
 pub const MSGPACK_EXT32: u8 = 0xc9;
 
 /// Float format family - Represents IEEE 754 floating point numbers
-/// Ref: https://github.com/msgpack/msgpack/blob/master/spec.md#formats-float
+/// Ref: <https://github.com/msgpack/msgpack/blob/master/spec.md#formats-float>
 pub const MSGPACK_FLOAT32: u8 = 0xca;
 pub const MSGPACK_FLOAT64: u8 = 0xcb;
 /// Unsigned integer format family - Represents unsigned integers
-/// Ref: https://github.com/msgpack/msgpack/blob/master/spec.md#int-format-family
+/// Ref: <https://github.com/msgpack/msgpack/blob/master/spec.md#int-format-family>
 pub const MSGPACK_UINT8: u8 = 0xcc;
 pub const MSGPACK_UINT16: u8 = 0xcd;
 pub const MSGPACK_UINT32: u8 = 0xce;
 pub const MSGPACK_UINT64: u8 = 0xcf;
 
 /// Signed integer format family - Represents signed integers
-/// Ref: https://github.com/msgpack/msgpack/blob/master/spec.md#int-format-family
+/// Ref: <https://github.com/msgpack/msgpack/blob/master/spec.md#int-format-family>
 pub const MSGPACK_INT8: u8 = 0xd0;
 pub const MSGPACK_INT16: u8 = 0xd1;
 pub const MSGPACK_INT32: u8 = 0xd2;
 pub const MSGPACK_INT64: u8 = 0xd3;
 
 /// Fixed-size extension format family - Represents custom type information with fixed-size byte arrays
-/// Ref: https://github.com/msgpack/msgpack/blob/master/spec.md#formats-ext
+/// Ref: <https://github.com/msgpack/msgpack/blob/master/spec.md#formats-ext>
 pub const MSGPACK_FIXEXT1: u8 = 0xd4;
 pub const MSGPACK_FIXEXT2: u8 = 0xd5;
 pub const MSGPACK_FIXEXT4: u8 = 0xd6;
@@ -48,47 +48,47 @@ pub const MSGPACK_FIXEXT8: u8 = 0xd7;
 pub const MSGPACK_FIXEXT16: u8 = 0xd8;
 
 /// String format family - Represents UTF-8 string
-/// Ref: https://github.com/msgpack/msgpack/blob/master/spec.md#formats-str
+/// Ref: <https://github.com/msgpack/msgpack/blob/master/spec.md#formats-str>
 pub const MSGPACK_STR8: u8 = 0xd9;
 pub const MSGPACK_STR16: u8 = 0xda;
 pub const MSGPACK_STR32: u8 = 0xdb;
 
 /// Array format family - Represents arrays of arbitrary values
-/// Ref: https://github.com/msgpack/msgpack/blob/master/spec.md#formats-array
+/// Ref: <https://github.com/msgpack/msgpack/blob/master/spec.md#formats-array>
 pub const MSGPACK_ARRAY16: u8 = 0xdc;
 pub const MSGPACK_ARRAY32: u8 = 0xdd;
 
 /// Map format family - Represents key-value maps
-/// Ref: https://github.com/msgpack/msgpack/blob/master/spec.md#formats-map
+/// Ref: <https://github.com/msgpack/msgpack/blob/master/spec.md#formats-map>
 pub const MSGPACK_MAP16: u8 = 0xde;
 pub const MSGPACK_MAP32: u8 = 0xdf;
 
 /// Positive fixint format family - Represents positive integers from 0 to 127 in a single byte
 /// The first bit is 0, and the remaining 7 bits store the value
-/// Ref: https://github.com/msgpack/msgpack/blob/master/spec.md#int-format-family
+/// Ref: <https://github.com/msgpack/msgpack/blob/master/spec.md#int-format-family>
 pub const MSGPACK_POSFIXINT_MIN: u8 = 0x00;
 pub const MSGPACK_POSFIXINT_MAX: u8 = 0x7f;
 
 /// Negative fixint format family - Represents negative integers from -1 to -32 in a single byte
 /// The first 3 bits are 111, and the remaining 5 bits store the absolute value minus 1
-/// Ref: https://github.com/msgpack/msgpack/blob/master/spec.md#int-format-family
+/// Ref: <https://github.com/msgpack/msgpack/blob/master/spec.md#int-format-family>
 pub const MSGPACK_NEGFIXINT_MIN: i8 = -0x20;
 pub const MSGPACK_NEGFIXINT_MAX: i8 = -0x01;
 
 /// Fixstr format family - Represents strings up to 31 bytes in a compact format
 /// The first 3 bits are 101, and the remaining 5 bits store the length
-/// Ref: https://github.com/msgpack/msgpack/blob/master/spec.md#formats-str
+/// Ref: <https://github.com/msgpack/msgpack/blob/master/spec.md#formats-str>
 pub const MSGPACK_FIXSTR_MIN: u8 = 0xa0;
 pub const MSGPACK_FIXSTR_MAX: u8 = 0xbf;
 
 /// Fixarray format family - Represents arrays with up to 15 elements in a compact format
 /// The first 4 bits are 1001, and the remaining 4 bits store the length
-/// Ref: https://github.com/msgpack/msgpack/blob/master/spec.md#formats-array
+/// Ref: <https://github.com/msgpack/msgpack/blob/master/spec.md#formats-array>
 pub const MSGPACK_FIXARRAY_MIN: u8 = 0x90;
 pub const MSGPACK_FIXARRAY_MAX: u8 = 0x9f;
 
 /// Fixmap format family - Represents maps with up to 15 key-value pairs in a compact format
 /// The first 4 bits are 1000, and the remaining 4 bits store the length
-/// Ref: https://github.com/msgpack/msgpack/blob/master/spec.md#formats-map
+/// Ref: <https://github.com/msgpack/msgpack/blob/master/spec.md#formats-map>
 pub const MSGPACK_FIXMAP_MIN: u8 = 0x80;
 pub const MSGPACK_FIXMAP_MAX: u8 = 0x8f;

--- a/shapely-msgpack/src/lib.rs
+++ b/shapely-msgpack/src/lib.rs
@@ -54,7 +54,7 @@ mod tests;
 ///
 /// # MessagePack Format
 /// This implementation follows the MessagePack specification:
-/// https://github.com/msgpack/msgpack/blob/master/spec.md
+/// <https://github.com/msgpack/msgpack/blob/master/spec.md>
 #[allow(clippy::needless_lifetimes)]
 pub fn from_msgpack(partial: &mut Partial, msgpack: &[u8]) -> Result<(), DecodeError> {
     let mut decoder = Decoder::new(msgpack);
@@ -160,7 +160,7 @@ impl<'input> Decoder<'input> {
     /// - uint32 (0xce): 32-bit unsigned integer (big-endian)
     /// - uint64 (0xcf): 64-bit unsigned integer (big-endian)
     ///
-    /// Ref: https://github.com/msgpack/msgpack/blob/master/spec.md#int-format-family
+    /// Ref: <https://github.com/msgpack/msgpack/blob/master/spec.md#int-format-family>
     fn decode_u64(&mut self) -> Result<u64, DecodeError> {
         match self.decode_u8()? {
             MSGPACK_UINT8 => Ok(self.decode_u8()? as u64),
@@ -188,7 +188,7 @@ impl<'input> Decoder<'input> {
     /// - str16 (0xda): string up to 65535 bytes
     /// - str32 (0xdb): string up to 4294967295 bytes
     ///
-    /// Ref: https://github.com/msgpack/msgpack/blob/master/spec.md#formats-str
+    /// Ref: <https://github.com/msgpack/msgpack/blob/master/spec.md#formats-str>
     fn decode_string(&mut self) -> Result<String, DecodeError> {
         let prefix = self.decode_u8()?;
 
@@ -216,7 +216,7 @@ impl<'input> Decoder<'input> {
     /// - map16 (0xde): map with up to 65535 elements
     /// - map32 (0xdf): map with up to 4294967295 elements
     ///
-    /// Ref: https://github.com/msgpack/msgpack/blob/master/spec.md#formats-map
+    /// Ref: <https://github.com/msgpack/msgpack/blob/master/spec.md#formats-map>
     fn decode_map_len(&mut self) -> Result<usize, DecodeError> {
         let prefix = self.decode_u8()?;
 

--- a/shapely-pretty/README.md
+++ b/shapely-pretty/README.md
@@ -6,13 +6,6 @@
 [![documentation](https://docs.rs/shapely-pretty/badge.svg)](https://docs.rs/shapely-pretty)
 [![MIT/Apache-2.0 licensed](https://img.shields.io/crates/l/shapely-pretty.svg)](./LICENSE)
 
-> [!IMPORTANT]
->
-> There is no stable shapely API as of now (even though it's >1.0.0). The design
-> is very much still being explored.
->
-> Expect multiple major versions in the near future — (note left 2025-03-11)
-
 A pretty-printing library for types implementing the `Shapely` trait, providing colorful and well-formatted output.
 
 ## Features

--- a/shapely-pretty/src/printer.rs
+++ b/shapely-pretty/src/printer.rs
@@ -7,7 +7,7 @@ use std::{
     str,
 };
 
-use shapely_core::{Innards, Scalar, ScalarContents, Shape, ShapeDesc, Shapely};
+use shapely_core::{FieldFlags, Innards, Scalar, ScalarContents, Shape, ShapeDesc, Shapely};
 
 use crate::{
     ansi,
@@ -249,7 +249,7 @@ impl PrettyPrinter {
             write!(f, "{}: ", self.style_field_name(field.name))?;
 
             // Check if field is sensitive
-            if field.flags.is_sensitive() {
+            if field.flags.contains(FieldFlags::SENSITIVE) {
                 // For sensitive fields, display [REDACTED] instead of the actual value
                 write!(f, "{}", self.style_redacted("[REDACTED]"))?;
             } else {

--- a/shapely-pretty/src/printer.rs
+++ b/shapely-pretty/src/printer.rs
@@ -134,7 +134,7 @@ impl PrettyPrinter {
                 vtable: _,
                 value_shape,
             } => self.format_hashmap(ptr, shape, *value_shape, f, depth, visited),
-            Innards::Array {
+            Innards::Vec {
                 vtable: _,
                 item_shape,
             } => self.format_array(ptr, shape, *item_shape, f, depth, visited),

--- a/shapely-pretty/tests/pretty_print.rs
+++ b/shapely-pretty/tests/pretty_print.rs
@@ -33,7 +33,7 @@ struct TestSecrets {
 impl Shapely for TestSecrets {
     fn shape() -> Shape {
         Shape {
-            name: |f| write!(f, "TestSecrets"),
+            name: |f, _opts| write!(f, "TestSecrets"),
             typeid: std::any::TypeId::of::<Self>(),
             layout: Layout::new::<Self>(),
             innards: Innards::Struct {

--- a/shapely-urlencoded/README.md
+++ b/shapely-urlencoded/README.md
@@ -6,13 +6,6 @@
 [![documentation](https://docs.rs/shapely-urlencoded/badge.svg)](https://docs.rs/shapely-urlencoded)
 [![MIT/Apache-2.0 licensed](https://img.shields.io/crates/l/shapely-urlencoded.svg)](./LICENSE)
 
-> [!IMPORTANT]
->
-> There is no stable shapely API as of now (even though it's >1.0.0). The design
-> is very much still being explored.
->
-> Expect multiple major versions in the near future — (note left 2025-03-11)
-
 A serialization and deserialization library for URL encoded form data using the shapely runtime reflection system.
 
 ## Features
@@ -53,7 +46,7 @@ Thanks to Namespace for providing fast GitHub Actions workers:
 
 Licensed under either of:
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your option.

--- a/shapely-urlencoded/src/lib.rs
+++ b/shapely-urlencoded/src/lib.rs
@@ -1,4 +1,5 @@
-#[doc = include_str!("../README.md")]
+#![doc = include_str!("../README.md")]
+
 use shapely::{Partial, error, trace, warn};
 
 #[cfg(test)]

--- a/shapely-yaml/README.md
+++ b/shapely-yaml/README.md
@@ -6,13 +6,6 @@
 [![documentation](https://docs.rs/shapely-yaml/badge.svg)](https://docs.rs/shapely-yaml)
 [![MIT/Apache-2.0 licensed](https://img.shields.io/crates/l/shapely-yaml.svg)](./LICENSE)
 
-> [!IMPORTANT]
->
-> There is no stable shapely API as of now (even though it's >1.0.0). The design
-> is very much still being explored.
->
-> Expect multiple major versions in the near future — (note left 2025-03-11)
-
 [YAML](https://yaml.org/) serialization and deserialization for Shapely types.
 
 ## Example
@@ -49,7 +42,7 @@ Thanks to Namespace for providing fast GitHub Actions workers:
 
 Licensed under either of:
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your option.

--- a/shapely/README.md
+++ b/shapely/README.md
@@ -6,13 +6,6 @@
 [![documentation](https://docs.rs/shapely/badge.svg)](https://docs.rs/shapely)
 [![MIT/Apache-2.0 licensed](https://img.shields.io/crates/l/shapely.svg)](./LICENSE)
 
-> [!IMPORTANT]
->
-> There is no stable shapely API as of now (even though it's >1.0.0). The design
-> is very much still being explored.
->
-> Expect multiple major versions in the near future — (note left 2025-03-11)
-
 shapely provides runtime reflection for Rust.
 
 Any type that implements `Shapely` trait returns a `Shape`, which describes:
@@ -133,7 +126,7 @@ Thanks to Namespace for providing fast GitHub Actions workers:
 
 Licensed under either of:
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your option.

--- a/shapely/README.md
+++ b/shapely/README.md
@@ -46,19 +46,22 @@ To implement a custom deserializer for a new format, you'll need to work with th
 
 ### Key Types
 
-- `Partial`: The central type for building shapely values incrementally
-- `Shape`: Describes the memory layout and structure of a type
-- `Innards`: Represents the internal structure (Scalar, Struct, etc.)
-- `Scalar`: Represents primitive types like String, u64, etc.
+- [`Partial`]: The central type for building shapely values incrementally
+- [`Shape`]: Describes the memory layout and structure of a type
+- [`Innards`]: Represents the internal structure (Scalar, Struct, etc.)
+- [`Scalar`]: Represents primitive types like String, u64, etc.
 
 ### Implementation Pattern
 
-1. Create a function that takes a `&mut Partial` and your format's input (string, bytes, etc.)
-2. Examine the shape of the partial using `partial.shape()`
-3. Handle different shapes based on `shape.innards`:
-   - For `Innards::Scalar`, use `partial.scalar_slot()` to get and fill the slot
-   - For `Innards::Struct`, iterate through fields, using `partial.slot_by_name(field_name)` to access each field
-   - Create nested `Partial` instances for complex fields and fill them recursively
+1. Create a function that takes a `&mut` [`Partial`] and your format's input (string, bytes, etc.)
+2. Examine the shape of the partial using [`Partial::shape`]
+3. Handle different shapes based on [`Shape::innards`]:
+   - For [`Innards::Scalar`], use [`Partial::scalar_slot`] to get and fill the slot
+   - For [`Innards::Struct`], iterate through fields, using [`Partial::slot_by_name`] to access each field
+   - [`Innards::HashMap`] and [`Innards::Array`] come with a vtable, they have helper slots as well
+   - Create nested [`Partial`] instances for complex fields and fill them recursively
+
+When in doubt, refer to the `shapely-json` implementation — it's the most featureful.
 
 ### Example Implementation Skeleton
 

--- a/shapely/README.md
+++ b/shapely/README.md
@@ -28,7 +28,12 @@ value is moved out of the partial.
 It comes with a derive macro that uses [unsynn](https://crates.io/crates/unsynn)
 for speed of compilation.
 
-## Supported Formats
+## Ecosystem
+
+The main `shapely` crate re-exports symbols from:
+
+- [shapely-core](../shapely-core), which defines the main `Shapely` trait and the `Shape` struct
+- [shapely-derive](../shapely-derive), which implements the `Shapely` derive attribute as a fast/light proc macro powered by [unsynn](https://docs.rs/unsynn)
 
 shapely supports deserialization from multiple data formats through dedicated crates:
 
@@ -36,6 +41,11 @@ shapely supports deserialization from multiple data formats through dedicated cr
 - [shapely-yaml](../shapely-yaml): YAML deserialization
 - [shapely-msgpack](../shapely-msgpack): MessagePack deserialization
 - [shapely-urlencoded](../shapely-urlencoded): URL-encoded form data deserialization
+
+Additionally:
+
+- [shapely-pretty](../shapely-pretty) is able to pretty-print Shapely types.
+- [shapely-codegen](../shapely-codegen) is internal and generates some of the code of `shapely-core`
 
 ## Implementing Your Own Deserializer
 

--- a/shapely/src/lib.rs
+++ b/shapely/src/lib.rs
@@ -1,3 +1,4 @@
-#[doc = include_str!("../README.md")]
+#![doc = include_str!("../README.md")]
+
 pub use shapely_core::*;
 pub use shapely_derive::*;


### PR DESCRIPTION
The `doc = include_str!()` attribute was missing a `!` so that it would apply to the crate, rather than to _every publicly re-exported item_.