### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ checksum = "b985e394ee53f8e4c547d5c6fa75b83b243ab6f51563a0323f1475fc8abc8e7f"
 
 [[package]]
 name = "shapely"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "shapely-derive",
  "shapely-spez",
@@ -114,11 +114,11 @@ dependencies = [
 
 [[package]]
 name = "shapely-codegen"
-version = "3.1.0"
+version = "3.1.1"
 
 [[package]]
 name = "shapely-derive"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "shapely-trait",
  "unsynn",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "shapely-json"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "color-backtrace",
  "ctor",
@@ -138,18 +138,18 @@ dependencies = [
 
 [[package]]
 name = "shapely-opaque"
-version = "3.1.0"
+version = "3.1.1"
 
 [[package]]
 name = "shapely-peek"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "shapely-trait",
 ]
 
 [[package]]
 name = "shapely-poke"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "color-backtrace",
  "ctor",
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "shapely-samplelibc"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "cc",
  "shapely",
@@ -170,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "shapely-spez"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "impls",
  "shapely-opaque",
@@ -179,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "shapely-trait"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "shapely-opaque",
  "shapely-spez",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "3.1.0"
+version = "3.1.1"
 authors = ["Amos Wenger <amos@bearcove.eu>"]
 edition = "2024"
 rust-version = "1.85"
@@ -34,6 +34,6 @@ keywords = [
 categories = ["encoding", "parsing", "development-tools", "data-structures"]
 
 [workspace.dependencies]
-shapely-trait = { version = "3.1.0", path = "shapely-trait" }
-shapely-derive = { version = "3.1.0", path = "shapely-derive" }
+shapely-trait = { version = "3.1.1", path = "shapely-trait" }
+shapely-derive = { version = "3.1.1", path = "shapely-derive" }
 unsynn = "0.0.25"

--- a/shapely-codegen/CHANGELOG.md
+++ b/shapely-codegen/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.1](https://github.com/bearcove/shapely/compare/shapely-codegen-v3.1.0...shapely-codegen-v3.1.1) - 2025-04-05
+
+### Fixed
+
+- fix errors now
+- fix errors
+
+### Other
+
+- 22 errors yay
+- tuples
+- alright well
+- tuples aw yiss
+- so close
+- whoa hey down to 111 errors
+- innards go in a struct
+- indirect vtable(), start fixing partial
+- tuples impl is up
+
 ## [3.1.0](https://github.com/bearcove/shapely/compare/shapely-codegen-v3.0.0...shapely-codegen-v3.1.0) - 2025-03-31
 
 ### Added

--- a/shapely-derive/CHANGELOG.md
+++ b/shapely-derive/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.1](https://github.com/bearcove/shapely/compare/shapely-derive-v3.1.0...shapely-derive-v3.1.1) - 2025-04-05
+
+### Fixed
+
+- fix errors now
+- fix derive probably
+
+### Other
+
+- Shapely is unsafe
+- json tests almost passing
+- errors gone
+- restore json test a little?? not much
+- everything... works?
+- DUMMY
+- 29 tests passed aw yiss
+- clone in place => clone into
+- mhhh getting somewhere
+- fun
+- Add more specializations
+- nice nice
+- I think it works????
+- getting somewhere maybe? but only in macros, they weren't joking.
+- ahhhhh
+- so far so god
+- make everything const??
+- Move tests to shapely proper
+- whoa hey down to 111 errors
+
 ## [3.1.0](https://github.com/bearcove/shapely/compare/shapely-derive-v3.0.0...shapely-derive-v3.1.0) - 2025-03-31
 
 ### Added

--- a/shapely-json/CHANGELOG.md
+++ b/shapely-json/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.1](https://github.com/bearcove/shapely/compare/shapely-json-v3.1.0...shapely-json-v3.1.1) - 2025-04-05
+
+### Fixed
+
+- fix json tests
+- fix miri/memory problems
+
+### Other
+
+- C demo
+- shapedebug bye
+- The split has gone well
+- woo everything builds
+- getting there
+- good, good
+- the rest is TODOs
+- json tests almost passing
+- quicksave
+- brrrr
+- set up json again
+- restore json test a little?? not much
+- Use spez-like ideas to set Debug if it's set on the type
+- alright, will this work?
+- Well the tests do pass
+- don't compare strings
+- Make CI pass
+- json works I guess
+- pv.shape eq is always true? woops
+- bit of json as a treat
+- introduce init_in_place_with_capacity
+- whoa hey down to 111 errors
+- Innards => Def
+- Introduce poke
+
 ## [3.1.0](https://github.com/bearcove/shapely/compare/shapely-json-v3.0.0...shapely-json-v3.1.0) - 2025-03-31
 
 ### Added

--- a/shapely-json/Cargo.toml
+++ b/shapely-json/Cargo.toml
@@ -15,7 +15,7 @@ rust-version.workspace = true
 [dependencies]
 log = "0.4.27"
 shapely-trait = { workspace = true }
-shapely-poke = { version = "3.1.0", path = "../shapely-poke" }
+shapely-poke = { version = "3.1.1", path = "../shapely-poke" }
 
 [dev-dependencies]
 color-backtrace = { version = "0.7.0", default-features = false, features = [

--- a/shapely-opaque/CHANGELOG.md
+++ b/shapely-opaque/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/shapely-peek/CHANGELOG.md
+++ b/shapely-peek/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [3.1.1](https://github.com/bearcove/shapely/compare/shapely-peek-v3.1.0...shapely-peek-v3.1.1) - 2025-04-05
+
+### Fixed
+
+- fix errors now
+
+### Other
+
+- C demo
+- getting there
+- Extract peek

--- a/shapely-poke/CHANGELOG.md
+++ b/shapely-poke/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [3.1.1](https://github.com/bearcove/shapely/compare/shapely-poke-v3.1.0...shapely-poke-v3.1.1) - 2025-04-05
+
+### Other
+
+- Add .envrc to try removing rebuilds
+- C demo
+- C example
+- shapedebug bye
+- woo everything builds
+- getting there
+- extract poke
+- Extract peek

--- a/shapely-poke/Cargo.toml
+++ b/shapely-poke/Cargo.toml
@@ -13,7 +13,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-shapely-peek = { version = "3.1.0", path = "../shapely-peek" }
+shapely-peek = { version = "3.1.1", path = "../shapely-peek" }
 shapely-trait.workspace = true
 
 [dev-dependencies]

--- a/shapely-samplelibc/Cargo.toml
+++ b/shapely-samplelibc/Cargo.toml
@@ -17,4 +17,4 @@ publish = false
 cc = "1.2.18"
 
 [dependencies]
-shapely = { version = "3.1.0", path = "../shapely" }
+shapely = { version = "3.1.1", path = "../shapely" }

--- a/shapely-spez/CHANGELOG.md
+++ b/shapely-spez/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [3.1.1](https://github.com/bearcove/shapely/compare/shapely-spez-v3.1.0...shapely-spez-v3.1.1) - 2025-04-05
+
+### Other
+
+- The great split
+- more divides

--- a/shapely-spez/Cargo.toml
+++ b/shapely-spez/Cargo.toml
@@ -14,5 +14,5 @@ categories.workspace = true
 
 [dependencies]
 impls = "1.0.3"
-shapely-opaque = { version = "3.1.0", path = "../shapely-opaque" }
+shapely-opaque = { version = "3.1.1", path = "../shapely-opaque" }
 shapely-types = { version = "0.1.0", path = "../shapely-types" }

--- a/shapely-trait/CHANGELOG.md
+++ b/shapely-trait/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [3.1.1](https://github.com/bearcove/shapely/compare/shapely-trait-v3.1.0...shapely-trait-v3.1.1) - 2025-04-05
+
+### Fixed
+
+- fix errors now
+
+### Other
+
+- Shapely is unsafe
+- Fix tests etc.
+- shapedebug bye
+- getting there
+- The great split

--- a/shapely-trait/Cargo.toml
+++ b/shapely-trait/Cargo.toml
@@ -13,6 +13,6 @@ keywords = ["reflection", "introspection", "serialization", "deserialization"]
 categories = ["development-tools", "encoding"]
 
 [dependencies]
-shapely-opaque = { version = "3.1.0", path = "../shapely-opaque" }
-shapely-spez = { version = "3.1.0", path = "../shapely-spez" }
+shapely-opaque = { version = "3.1.1", path = "../shapely-opaque" }
+shapely-spez = { version = "3.1.1", path = "../shapely-spez" }
 shapely-types = { version = "0.1.0", path = "../shapely-types" }

--- a/shapely-types/CHANGELOG.md
+++ b/shapely-types/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/bearcove/shapely/releases/tag/shapely-types-v0.1.0) - 2025-04-05
+
+### Other
+
+- remove macos-only test
+- shapedebug bye
+- The great split
+- more divides

--- a/shapely-types/Cargo.toml
+++ b/shapely-types/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2024"
 
 [dependencies]
 bitflags = "2.9.0"
-shapely-opaque = { version = "3.1.0", path = "../shapely-opaque" }
+shapely-opaque = { version = "3.1.1", path = "../shapely-opaque" }
 typeid = "1.0.3"

--- a/shapely/CHANGELOG.md
+++ b/shapely/CHANGELOG.md
@@ -7,6 +7,81 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.1](https://github.com/bearcove/shapely/compare/shapely-v3.1.0...shapely-v3.1.1) - 2025-04-05
+
+### Fixed
+
+- fix errors now
+- fix miri/memory problems
+- fix derive probably
+
+### Other
+
+- Add .envrc to try removing rebuilds
+- Shapely is unsafe
+- Fix tests etc.
+- woo everything builds
+- getting there
+- The great split
+- start fixing doc tests
+- Cool, the hacking guide is in
+- 29 tests passed aw yiss
+- clone stuff
+- clone in place => clone into
+- mhmh
+- mhhh getting somewhere
+- fun
+- bigger and bigger
+- switch to btparse
+- time to fix those tests
+- mhmhmh
+- color backtrace in tests please?
+- tests are made to fail
+- mhmh tests are failing huh
+- maps, slowlyl
+- peeking a lotta things
+- more vec stuff
+- okay, debug and default, it's something
+- mhh we regressed
+- Uhhh slices work?
+- well this weirdly works?
+- mhkay
+- traits tests look better
+- more spez is going well
+- mh
+- mhhhmhh
+- mhhhhh it's probably the uninit thing, ngl
+- I'm confused now
+- uhhhh
+- uhhh what
+- weird
+- more tests
+- More tests
+- rename spez to traits
+- mhmhmh
+- Uncomment a bunch of tests
+- Unreasonably happy with that tbh
+- nice nice
+- Use spez-like ideas to set Debug if it's set on the type
+- Well that's not really const
+- yessssss
+- getting somewhere maybe? but only in macros, they weren't joking.
+- mhhh
+- ahhhhh
+- alright, will this work?
+- Mhh doesn't work yet
+- Well the tests do pass
+- welp
+- don't compare strings
+- uncomment some derives
+- so far so god
+- new structure works
+- introduce init_in_place_with_capacity
+- Rname more things for more consistency
+- Move tests to shapely proper
+- whoa hey down to 111 errors
+- Innards => Def
+
 ## [3.1.0](https://github.com/bearcove/shapely/compare/shapely-v3.0.0...shapely-v3.1.0) - 2025-03-31
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `shapely-opaque`: 3.1.0 -> 3.1.1
* `shapely-types`: 0.1.0
* `shapely-spez`: 3.1.0 -> 3.1.1
* `shapely-trait`: 3.1.0 -> 3.1.1
* `shapely-derive`: 3.1.0 -> 3.1.1
* `shapely`: 3.1.0 -> 3.1.1 (✓ API compatible changes)
* `shapely-codegen`: 3.1.0 -> 3.1.1
* `shapely-peek`: 3.1.0 -> 3.1.1 (✓ API compatible changes)
* `shapely-poke`: 3.1.0 -> 3.1.1
* `shapely-json`: 3.1.0 -> 3.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


## `shapely-types`

<blockquote>

## [0.1.0](https://github.com/bearcove/shapely/releases/tag/shapely-types-v0.1.0) - 2025-04-05

### Other

- remove macos-only test
- shapedebug bye
- The great split
- more divides
</blockquote>

## `shapely-spez`

<blockquote>

## [3.1.1](https://github.com/bearcove/shapely/compare/shapely-spez-v3.1.0...shapely-spez-v3.1.1) - 2025-04-05

### Other

- The great split
- more divides
</blockquote>

## `shapely-trait`

<blockquote>

## [3.1.1](https://github.com/bearcove/shapely/compare/shapely-trait-v3.1.0...shapely-trait-v3.1.1) - 2025-04-05

### Fixed

- fix errors now

### Other

- Shapely is unsafe
- Fix tests etc.
- shapedebug bye
- getting there
- The great split
</blockquote>

## `shapely-derive`

<blockquote>

## [3.1.1](https://github.com/bearcove/shapely/compare/shapely-derive-v3.1.0...shapely-derive-v3.1.1) - 2025-04-05

### Fixed

- fix errors now
- fix derive probably

### Other

- Shapely is unsafe
- json tests almost passing
- errors gone
- restore json test a little?? not much
- everything... works?
- DUMMY
- 29 tests passed aw yiss
- clone in place => clone into
- mhhh getting somewhere
- fun
- Add more specializations
- nice nice
- I think it works????
- getting somewhere maybe? but only in macros, they weren't joking.
- ahhhhh
- so far so god
- make everything const??
- Move tests to shapely proper
- whoa hey down to 111 errors
</blockquote>

## `shapely`

<blockquote>

## [3.1.1](https://github.com/bearcove/shapely/compare/shapely-v3.1.0...shapely-v3.1.1) - 2025-04-05

### Fixed

- fix errors now
- fix miri/memory problems
- fix derive probably

### Other

- Add .envrc to try removing rebuilds
- Shapely is unsafe
- Fix tests etc.
- woo everything builds
- getting there
- The great split
- start fixing doc tests
- Cool, the hacking guide is in
- 29 tests passed aw yiss
- clone stuff
- clone in place => clone into
- mhmh
- mhhh getting somewhere
- fun
- bigger and bigger
- switch to btparse
- time to fix those tests
- mhmhmh
- color backtrace in tests please?
- tests are made to fail
- mhmh tests are failing huh
- maps, slowlyl
- peeking a lotta things
- more vec stuff
- okay, debug and default, it's something
- mhh we regressed
- Uhhh slices work?
- well this weirdly works?
- mhkay
- traits tests look better
- more spez is going well
- mh
- mhhhmhh
- mhhhhh it's probably the uninit thing, ngl
- I'm confused now
- uhhhh
- uhhh what
- weird
- more tests
- More tests
- rename spez to traits
- mhmhmh
- Uncomment a bunch of tests
- Unreasonably happy with that tbh
- nice nice
- Use spez-like ideas to set Debug if it's set on the type
- Well that's not really const
- yessssss
- getting somewhere maybe? but only in macros, they weren't joking.
- mhhh
- ahhhhh
- alright, will this work?
- Mhh doesn't work yet
- Well the tests do pass
- welp
- don't compare strings
- uncomment some derives
- so far so god
- new structure works
- introduce init_in_place_with_capacity
- Rname more things for more consistency
- Move tests to shapely proper
- whoa hey down to 111 errors
- Innards => Def
</blockquote>

## `shapely-codegen`

<blockquote>

## [3.1.1](https://github.com/bearcove/shapely/compare/shapely-codegen-v3.1.0...shapely-codegen-v3.1.1) - 2025-04-05

### Fixed

- fix errors now
- fix errors

### Other

- 22 errors yay
- tuples
- alright well
- tuples aw yiss
- so close
- whoa hey down to 111 errors
- innards go in a struct
- indirect vtable(), start fixing partial
- tuples impl is up
</blockquote>

## `shapely-peek`

<blockquote>

## [3.1.1](https://github.com/bearcove/shapely/compare/shapely-peek-v3.1.0...shapely-peek-v3.1.1) - 2025-04-05

### Fixed

- fix errors now

### Other

- C demo
- getting there
- Extract peek
</blockquote>

## `shapely-poke`

<blockquote>

## [3.1.1](https://github.com/bearcove/shapely/compare/shapely-poke-v3.1.0...shapely-poke-v3.1.1) - 2025-04-05

### Other

- Add .envrc to try removing rebuilds
- C demo
- C example
- shapedebug bye
- woo everything builds
- getting there
- extract poke
- Extract peek
</blockquote>

## `shapely-json`

<blockquote>

## [3.1.1](https://github.com/bearcove/shapely/compare/shapely-json-v3.1.0...shapely-json-v3.1.1) - 2025-04-05

### Fixed

- fix json tests
- fix miri/memory problems

### Other

- C demo
- shapedebug bye
- The split has gone well
- woo everything builds
- getting there
- good, good
- the rest is TODOs
- json tests almost passing
- quicksave
- brrrr
- set up json again
- restore json test a little?? not much
- Use spez-like ideas to set Debug if it's set on the type
- alright, will this work?
- Well the tests do pass
- don't compare strings
- Make CI pass
- json works I guess
- pv.shape eq is always true? woops
- bit of json as a treat
- introduce init_in_place_with_capacity
- whoa hey down to 111 errors
- Innards => Def
- Introduce poke
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).